### PR TITLE
Hunter Fixes

### DIFF
--- a/sql/database_updates/20260809183358_world.sql
+++ b/sql/database_updates/20260809183358_world.sql
@@ -1,0 +1,394 @@
+-- ==============================================
+-- FILE: bestial_discipline.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_affect`
+(
+    `entry`,
+    `effectId`,
+    `SpellFamilyMask`
+)
+VALUES
+(19590, 1, 1649267441664),
+(19592, 1, 1649267441664);
+
+-- ==============================================
+-- FILE: bestial_wrath.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_bestial_wrath'
+WHERE `entry` = 19574;
+
+-- ==============================================
+-- FILE: coordinated_assault.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_strike_together_damage'
+WHERE `entry` = 49557;
+
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_coordinated_assault'
+WHERE `entry` = 49559;
+
+INSERT INTO `spell_proc_event`
+(
+    `entry`,
+    `SchoolMask`,
+    `SpellFamilyName`,
+    `SpellFamilyMask0`,
+    `SpellFamilyMask1`,
+    `SpellFamilyMask2`,
+    `procFlags`,
+    `procEx`,
+    `ppmRate`,
+    `CustomChance`,
+    `Cooldown`
+)
+VALUES
+(49559, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3);
+-- ==============================================
+-- FILE: efficiency.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_affect`
+(
+    `entry`,
+    `effectId`,
+    `SpellFamilyMask`
+)
+VALUES
+(19416, 0, 68719999488),
+(19417, 0, 68719999488),
+(19418, 0, 68719999488),
+(19419, 0, 68719999488),
+(19420, 0, 68719999488);
+
+-- ==============================================
+-- FILE: endless_quiver.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_proc_event`
+(
+    `entry`,
+    `SchoolMask`,
+    `SpellFamilyName`,
+    `SpellFamilyMask0`,
+    `SpellFamilyMask1`,
+    `SpellFamilyMask2`,
+    `procFlags`,
+    `procEx`,
+    `ppmRate`,
+    `CustomChance`,
+    `Cooldown`
+)
+VALUES
+(51517, 0, 9, 68719613953, 0, 0, 0, 0, 0, 0, 0),
+(51518, 0, 9, 68719613953, 0, 0, 0, 0, 0, 0, 0);
+
+-- ==============================================
+-- FILE: experimental_ammunition.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_experimental_ammunition'
+WHERE `entry` = 58108;
+
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_experimental_ammunition_trigger'
+WHERE `entry` IN (
+    58112, 58113, 58114
+    );
+
+UPDATE `spell_template`
+SET `customFlags` = 16384
+WHERE `entry` = 58113;
+
+-- ==============================================
+-- FILE: hawk_eye.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_affect`
+(
+    `entry`,
+    `effectId`,
+    `SpellFamilyMask`
+)
+VALUES
+(19498, 0, 68719999489),
+(19499, 0, 68719999489);
+
+-- ==============================================
+-- FILE: improved_marksmanship.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_affect`
+(
+    `entry`,
+    `effectId`,
+    `SpellFamilyMask`
+)
+VALUES
+(51515, 0, 68719607808),
+(51516, 0, 68719607808);
+
+-- ==============================================
+-- FILE: improved_primal_aspects.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_improved_primal_aspects'
+WHERE `entry` IN (
+    19549, 19550, 19551
+    );
+
+-- ==============================================
+-- FILE: kill_command.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_kill_command'
+WHERE `entry` = 41827;
+
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_kill_command_damage'
+WHERE `entry` = 41828;
+
+-- ==============================================
+-- FILE: lacerate.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_lacerate'
+WHERE `entry` = 48049;
+
+-- ==============================================
+-- FILE: lock_and_load.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_proc_event`
+(
+    `entry`,
+    `SchoolMask`,
+    `SpellFamilyName`,
+    `SpellFamilyMask0`,
+    `SpellFamilyMask1`,
+    `SpellFamilyMask2`,
+    `procFlags`,
+    `procEx`,
+    `ppmRate`,
+    `CustomChance`,
+    `Cooldown`
+)
+VALUES
+(52920, 0, 9, 68719609856, 0, 0, 256, 2, 0, 0, 0);
+
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_lock_and_load'
+WHERE `entry` = 52920;
+
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_aimed_shot'
+WHERE `entry` IN (
+    19434, 20900, 20901, 20902, 20903, 20904, 27632
+    );
+
+-- ==============================================
+-- FILE: piercing_shots.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_proc_event`
+(
+    `entry`,
+    `SchoolMask`,
+    `SpellFamilyName`,
+    `SpellFamilyMask0`,
+    `SpellFamilyMask1`,
+    `SpellFamilyMask2`,
+    `procFlags`,
+    `procEx`,
+    `ppmRate`,
+    `CustomChance`,
+    `Cooldown`
+)
+VALUES
+(51512, 0, 9, 68719611904, 0, 0, 256, 2, 0, 0, 0),
+(51513, 0, 9, 68719611904, 0, 0, 256, 2, 0, 0, 0);
+
+INSERT INTO `spell_threat`
+(
+    `entry`,
+    `Threat`,
+    `multiplier`,
+    `ap_bonus`
+)
+VALUES
+(51514, 0, 0, 0);
+
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_piercing_shots'
+WHERE `entry` IN (
+    51512, 51513
+    );
+
+-- ==============================================
+-- FILE: resourcefulness.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_affect`
+(
+    `entry`,
+    `effectId`,
+    `SpellFamilyMask`
+)
+VALUES
+(51570, 0, 420906795330),
+(51571, 0, 420906795330),
+(51572, 0, 420906795330),
+(51573, 0, 420906795330),
+(51574, 0, 420906795330);
+
+-- ==============================================
+-- FILE: savage_strikes.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_affect`
+(
+    `entry`,
+    `effectId`,
+    `SpellFamilyMask`
+)
+VALUES
+(19159, 0, 283467841536),
+(19160, 0, 283467841536);
+
+-- ==============================================
+-- FILE: swift_aspects.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_swift_aspects'
+WHERE `entry` IN (
+    19552, 19553, 19554, 19555, 19556
+    );
+
+-- ==============================================
+-- FILE: trainer_updates.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `npc_trainer`
+SET `spellcost` = 2200, `reqlevel` = 20
+WHERE `spell` = 1424;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 200, `reqlevel` = 8
+WHERE `spell` = 3128;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 400
+WHERE `spell` = 47296;
+
+UPDATE `npc_trainer`
+SET `reqlevel` = 20
+WHERE `spell` = 47319;
+
+UPDATE `npc_trainer`
+SET `reqlevel` = 30
+WHERE `spell` = 47320;
+
+UPDATE `npc_trainer`
+SET `reqlevel` = 40
+WHERE `spell` = 47321;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 36000, `reqlevel` = 50
+WHERE `spell` = 47322;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 50000, `reqlevel` = 60
+WHERE `spell` = 47323;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 46000
+WHERE `spell` = 47338;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 8000
+WHERE `spell` = 51503;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 16000
+WHERE `spell` = 51504;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 32000
+WHERE `spell` = 51505;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 48000
+WHERE `spell` = 51506;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 800
+WHERE `spell` = 52417;
+
+UPDATE `npc_trainer`
+SET `spellcost` = 900
+WHERE `spell` = 52418;
+
+-- ==============================================
+-- FILE: traps.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+INSERT INTO `spell_mod`
+(
+    `Id`,
+    `Attributes`,
+    `Comment`
+)
+VALUES
+(1499, 268500992, 'Hunter traps: cannot be used in combat'),
+(13795, 268500992, 'Hunter traps: cannot be used in combat'),
+(13809, 268500992, 'Hunter traps: cannot be used in combat'),
+(13813, 268500992, 'Hunter traps: cannot be used in combat'),
+(14302, 268500992, 'Hunter traps: cannot be used in combat'),
+(14303, 268500992, 'Hunter traps: cannot be used in combat'),
+(14304, 268500992, 'Hunter traps: cannot be used in combat'),
+(14305, 268500992, 'Hunter traps: cannot be used in combat'),
+(14310, 268500992, 'Hunter traps: cannot be used in combat'),
+(14311, 268500992, 'Hunter traps: cannot be used in combat'),
+(14316, 268500992, 'Hunter traps: cannot be used in combat'),
+(14317, 268500992, 'Hunter traps: cannot be used in combat');
+
+-- ==============================================
+-- FILE: untamed_trapper.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_trap'
+WHERE `entry` IN (
+    1499, 13795, 13809, 13813, 14302, 14303, 14304, 14305, 14310, 14311,
+    14316, 14317
+    );
+
+-- ==============================================
+-- FILE: volley.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `script_name` = 'spell_hunter_volley'
+WHERE `entry` IN (
+    1510, 14294, 14295
+    );
+
+-- ==============================================
+-- FILE: poison_spit.sql
+-- GENERATED: 20260809183358
+-- ==============================================
+UPDATE `spell_template`
+SET `effectBonusCoefficient1` = 0.25
+WHERE `entry` IN (
+    46271, 46272, 46273
+    );
+

--- a/src/game/Objects/Object.cpp
+++ b/src/game/Objects/Object.cpp
@@ -3656,7 +3656,19 @@ uint32 WorldObject::GetWeaponSkillValue(WeaponAttackType attType, WorldObject co
         return pPlayer->GetSkillValue(skill);
     }
 
-    return GetUnitMeleeSkill(target);
+    uint32 skill = GetUnitMeleeSkill(target);
+    if (Pet const* pet = ToPet())
+    {
+        if (Unit const* owner = pet->GetOwner())
+        {
+            if (owner->HasAura(51555))      // Bestial Precision Rank 2
+                skill += 10;
+            else if (owner->HasAura(51554)) // Bestial Precision Rank 1
+                skill += 5;
+        }
+    }
+
+    return skill;
 }
 
 uint32 WorldObject::GetDefenseSkillValue(WorldObject const* target) const
@@ -4866,6 +4878,7 @@ uint32 WorldObject::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellP
 
     float DoneTotalMod = 1.0f;
     int32 DoneTotal = 0;
+    int32 DoneTotalNoCoeff = 0;
     Item*  pWeapon = GetTypeId() == TYPEID_PLAYER ? ((Player*)this)->GetWeaponForAttack(BASE_ATTACK, true, false) : nullptr;
 
     // Creature damage
@@ -4931,6 +4944,41 @@ uint32 WorldObject::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellP
                 continue;
             switch (i->GetModifier()->m_miscvalue)
             {
+                case 5066:
+                {
+                    if (!owner->HasAura(51578))
+                        DoneTotalMod += i->GetModifier()->m_amount / 100.0f;
+                    break;
+                }
+                case 5067: // Trap Mastery
+                {
+                    DoneTotalMod += i->GetModifier()->m_amount / 100.0f;
+                    break;
+                }
+                case 5068: // Untamed Trapper
+                {
+                    float const attackPower = owner->GetTotalAttackPowerValue(BASE_ATTACK);
+                    switch (spellProto->Id)
+                    {
+                        case 13797:
+                        case 14298:
+                        case 14299:
+                        case 14300:
+                        case 14301:
+                            if (effectIndex == EFFECT_INDEX_0)
+                                DoneTotalNoCoeff += int32(attackPower / 10.0f);
+                            break;
+                        case 13812:
+                        case 14314:
+                        case 14315:
+                            if (effectIndex == EFFECT_INDEX_0)
+                                DoneTotalNoCoeff += int32(attackPower / 6.5f);
+                            else if (effectIndex == EFFECT_INDEX_1)
+                                DoneTotalNoCoeff += int32(attackPower / 30.0f);
+                            break;
+                    }
+                    break;
+                }
                 case 4418: // Increased Shock Damage
                 case 4554: // Increased Lightning Damage
                 {
@@ -4975,7 +5023,7 @@ uint32 WorldObject::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellP
     // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
     DoneTotal = SpellBonusWithCoeffs(spellProto, effectIndex, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true, this, spell);
 
-    float tmpDamage = (int32(pdamage) + DoneTotal * int32(stack)) * DoneTotalMod;
+    float tmpDamage = (int32(pdamage) + (DoneTotal + DoneTotalNoCoeff) * int32(stack)) * DoneTotalMod;
     // apply spellmod to Done damage (flat and pct)
     if (pUnit)
     {

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -1386,8 +1386,10 @@ struct SpellScript
     virtual void OnSuccessfulFinish(Spell* /*spell*/) const {}
     virtual void OnFinish(Spell* /*spell*/, bool /*ok*/) const {}
     virtual SpellCastResult OnCheckCast(Spell* /*spell*/, bool /*strict*/) const { return SPELL_CAST_OK; }
+    virtual bool OnCanCastNonCombatSpellInCombat(Spell* /*spell*/) const { return false; }
     virtual std::optional<uint32> OnCalculatePowerCost(SpellEntry const* /*spellInfo*/, Unit* /*caster*/, Spell* /*spell*/, Item* /*castItem*/) const { return std::nullopt; }
     virtual bool OnTakePower(Spell* /*spell*/) const { return true; }
+    virtual bool OnTakeAmmo(Spell* /*spell*/) const { return true; }
     virtual void OnEffectDamageCalculate(Spell* /*spell*/, SpellEffectIndex /*effIdx*/, float& /*damage*/) const {}
     virtual void OnSpellCritChanceCalculate(Spell* /*spell*/, Unit const* /*victim*/, float& /*critChance*/) const {}
     virtual bool OnEffectHealCalculate(Spell* /*spell*/, SpellEffectIndex /*effIdx*/, int32& /*heal*/) const { return true; }

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5329,6 +5329,9 @@ void Spell::TakeAmmo()
     if (!pCaster)
         return;
 
+    if (m_spellScript && !m_spellScript->OnTakeAmmo(this))
+        return;
+
     // Some ranged attacks dont take any ammo
     switch (m_spellInfo->Id)
     {
@@ -5336,6 +5339,7 @@ void Spell::TakeAmmo()
         case 13099: // Net-o-Matic
         case 13119: // Net-o-Matic
         case 23577: // Expose Weakness
+        case 51514: // Piercing Shots
             return;
     }
             
@@ -5574,7 +5578,8 @@ SpellCastResult Spell::CheckCast(bool strict)
 
         if (strict && m_casterUnit)
         {
-            if (m_casterUnit && m_casterUnit->IsInCombat() && m_spellInfo->IsNonCombatSpell())
+            if (m_casterUnit && m_casterUnit->IsInCombat() && m_spellInfo->IsNonCombatSpell() &&
+                    (!m_spellScript || !m_spellScript->OnCanCastNonCombatSpellInCombat(this)))
                 return SPELL_FAILED_AFFECTING_COMBAT;
 
             // only check at first call, Stealth auras are already removed at second call
@@ -5617,16 +5622,6 @@ SpellCastResult Spell::CheckCast(bool strict)
             if ((!m_caster->m_movementInfo.HasMovementFlag(MOVEFLAG_FALLINGFAR) || m_spellInfo->Effect[EFFECT_INDEX_0] != SPELL_EFFECT_STUCK) &&
                     (IsAutoRepeat() || m_spellInfo->AuraInterruptFlags & AURA_INTERRUPT_FLAG_NOT_SEATED))
                 return SPELL_FAILED_MOVING;
-        }
-
-        //CUSTOM Aspect of the wolf can not use ranged attacks.
-        if (m_caster->ToPlayer()->HasAura(45650))
-        {
-            if (m_spellInfo->IsAutoRepeatRangedSpell() || (m_spellInfo->Attributes & SPELL_ATTR_RANGED))
-            {
-                m_caster->ToPlayer()->GetSession()->SendNotification("Can\'t use that in this Aspect.");
-                return SPELL_FAILED_DONT_REPORT;
-            }
         }
 
         if (!m_IsTriggeredSpell && m_spellInfo->NeedsComboPoints() && Spells::IsExplicitlySelectedUnitTarget(m_spellInfo->EffectImplicitTargetA[0]) &&

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -287,8 +287,8 @@ pAuraHandler AuraHandler[TOTAL_AURAS] =
     &Aura::HandlePeriodicTriggerSpellWithValue,              //218 SPELL_AURA_PERIODIC_TRIGGER_SPELL2
     &Aura::HandleUnused,                                    //219 SPELL_AURA_219
     &Aura::HandleNoImmediateEffect,                         //220 SPELL_AURA_MOD_DAMAGE_TAKEN_FROM_CASTER_PET implemented in Unit::MeleeDamageBonusTaken and SpellDamageBonusTaken
-    &Aura::HandleAuraModAttackPower,                        //221 SPELL_AURA_MOD_ATTACK_POWER_AREA
-    &Aura::HandleAuraModAttackPowerPercent,                 //222 SPELL_AURA_MOD_ATTACK_POWER_PERCENT_AREA
+    &Aura::HandleAuraModAttackPowerArea,                    //221 SPELL_AURA_MOD_ATTACK_POWER_AREA
+    &Aura::HandleAuraModAttackPowerPercentArea,             //222 SPELL_AURA_MOD_ATTACK_POWER_PERCENT_AREA
     &Aura::HandleNoImmediateEffect,                         //223 SPELL_AURA_MOD_ITEM_PROC_CHANCE implemented in Player::CastItemCombatSpell
     &Aura::HandleNoImmediateEffect,                         //224 SPELL_AURA_MOD_BLOCK_DAMAGE_PERCENT implemented in Unit::CalculateAbsorbResistBlock
     &Aura::HandleNoImmediateEffect,                         //225 SPELL_AURA_MOD_GATHERING_ITEM_CHANCE
@@ -5142,6 +5142,12 @@ void Aura::HandleAuraModAttackPower(bool apply, bool /*Real*/)
     CheckRangedOverrides(GetTarget(), this, apply, m_modifier.m_amount);
 }
 
+void Aura::HandleAuraModAttackPowerArea(bool apply, bool Real)
+{
+    HandleAuraModAttackPower(apply, Real);
+    GetTarget()->HandleAttackPowerModifier(RANGED_AP_MODS, IsPositive() ? AP_MOD_POSITIVE_FLAT : AP_MOD_NEGATIVE_FLAT, m_modifier.m_amount, apply);
+}
+
 void Aura::HandleAuraModRangedAttackPower(bool apply, bool /*Real*/)
 {
     if ((GetTarget()->GetClassMask() & CLASSMASK_WAND_USERS) != 0)
@@ -5168,6 +5174,12 @@ void Aura::HandleAuraModAttackPowerPercent(bool apply, bool /*Real*/)
 
     // UNIT_FIELD_ATTACK_POWER_MULTIPLIER = multiplier - 1
     GetTarget()->HandleAttackPowerModifier(MELEE_AP_MODS, AP_MOD_PCT, m_modifier.m_amount, apply);
+}
+
+void Aura::HandleAuraModAttackPowerPercentArea(bool apply, bool Real)
+{
+    HandleAuraModAttackPowerPercent(apply, Real);
+    GetTarget()->HandleAttackPowerModifier(RANGED_AP_MODS, AP_MOD_PCT, m_modifier.m_amount, apply);
 }
 
 void Aura::HandleAuraModRangedAttackPowerPercent(bool apply, bool /*Real*/)

--- a/src/game/Spells/SpellAuras.h
+++ b/src/game/Spells/SpellAuras.h
@@ -400,6 +400,7 @@ class Aura
         void HandleChannelDeathItem(bool Apply, bool Real);
         void HandlePeriodicDamagePCT(bool Apply, bool Real);
         void HandleAuraModAttackPower(bool Apply, bool Real);
+        void HandleAuraModAttackPowerArea(bool Apply, bool Real);
         void HandleAuraTransform(bool Apply, bool Real);
         void HandleModSpellCritChance(bool Apply, bool Real);
         void HandleAuraModIncreaseSwimSpeed(bool Apply, bool Real);
@@ -430,6 +431,7 @@ class Aura
         void HandleAuraModPacify(bool Apply, bool Real);
         void HandleAuraGhost(bool Apply, bool Real);
         void HandleAuraModAttackPowerPercent(bool apply, bool Real);
+        void HandleAuraModAttackPowerPercentArea(bool apply, bool Real);
         void HandleAuraModRangedAttackPowerPercent(bool apply, bool Real);
         void HandleSpiritOfRedemption(bool apply, bool Real);
         void HandleAuraAoeCharm(bool apply, bool real);

--- a/src/game/Spells/SpellEntry.cpp
+++ b/src/game/Spells/SpellEntry.cpp
@@ -1,6 +1,7 @@
 #include "SpellEntry.h"
 #include "SharedDefines.h"
 #include "SpellAuraDefines.h"
+#include "SpellAuras.h"
 #include "SpellMgr.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
@@ -101,8 +102,9 @@ SpellSpecific Spells::GetSpellSpecific(uint32 spellId)
             if (spellInfo->Dispel == DISPEL_POISON)
                 return SPELL_STING;
 
-            // only hunter aspects have this (one have generic family), if exclude Auto Shot
-            if (spellInfo->activeIconID == 122 && spellInfo->Id != 75)
+            // only hunter aspects have this (one have generic family), if exclude Auto Shot and Trueshot Aura
+            if (spellInfo->activeIconID == 122 && spellInfo->Id != 75 &&
+                    spellInfo->Id != 19506 && spellInfo->Id != 20905 && spellInfo->Id != 20906)
                 return SPELL_ASPECT;
 
             break;
@@ -823,7 +825,19 @@ int32 SpellEntry::CalculateDuration(WorldObject const* caster, Unit const* targe
         {
             if (Player* modOwner = pUnit->GetSpellModOwner())
             {
+                int32 const durationBeforeSpellMods = duration;
                 modOwner->ApplySpellMod(Id, SPELLMOD_DURATION, duration);
+
+                Unit::AuraList const& overrideClassScripts = modOwner->GetAurasByType(SPELL_AURA_OVERRIDE_CLASS_SCRIPTS);
+                for (Aura const* aura : overrideClassScripts)
+                {
+                    if (aura->GetModifier()->m_miscvalue != 5066 ||
+                        modOwner->HasAura(51578) ||
+                        !aura->isAffectedOnSpell(this))
+                        continue;
+
+                    duration += int32(durationBeforeSpellMods * aura->GetModifier()->m_amount / 100.0f);
+                }
 
                 if (duration < 0)
                     duration = 0;

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -1138,6 +1138,26 @@ bool SpellMgr::IsNoStackSpellDueToSpell(uint32 spellId_1, uint32 spellId_2) cons
                         ((spellInfo_2->SpellFamilyFlags & UI64LIT(0x4)) && (spellInfo_1->SpellFamilyFlags & UI64LIT(0x00000004000))))
                     return false;
 
+                // Poison Spit & Immolation Trap Effect
+                if (((spellInfo_1->SpellFamilyFlags & UI64LIT(0x4)) && (spellInfo_2->SpellFamilyFlags & UI64LIT(0x8000000000))) ||
+                        ((spellInfo_2->SpellFamilyFlags & UI64LIT(0x4)) && (spellInfo_1->SpellFamilyFlags & UI64LIT(0x8000000000))))
+                    return false;
+
+                // Lacerate & Immolation Trap Effect
+                if (((spellInfo_1->SpellFamilyFlags & UI64LIT(0x4)) && (spellInfo_2->SpellFamilyFlags & UI64LIT(0x4000000000))) ||
+                        ((spellInfo_2->SpellFamilyFlags & UI64LIT(0x4)) && (spellInfo_1->SpellFamilyFlags & UI64LIT(0x4000000000))))
+                    return false;
+
+                // Lacerate & Poison Spit
+                if (((spellInfo_1->SpellFamilyFlags & UI64LIT(0x8000000000)) && (spellInfo_2->SpellFamilyFlags & UI64LIT(0x4000000000))) ||
+                        ((spellInfo_2->SpellFamilyFlags & UI64LIT(0x8000000000)) && (spellInfo_1->SpellFamilyFlags & UI64LIT(0x4000000000))))
+                    return false;
+
+                // Serpent Sting & Lacerate
+                if (((spellInfo_1->SpellFamilyFlags & UI64LIT(0x00000004000)) && (spellInfo_2->SpellFamilyFlags & UI64LIT(0x4000000000))) ||
+                        ((spellInfo_2->SpellFamilyFlags & UI64LIT(0x00000004000)) && (spellInfo_1->SpellFamilyFlags & UI64LIT(0x4000000000))))
+                    return false;
+
                 // Bestial Wrath
                 if (spellInfo_1->SpellIconID == 1680 && spellInfo_2->SpellIconID == 1680)
                     return false;

--- a/src/scripts/spells/spell_hunter.cpp
+++ b/src/scripts/spells/spell_hunter.cpp
@@ -2,6 +2,91 @@
 
 namespace
 {
+enum HunterSpells
+{
+    SPELL_HUNTER_VOLLEY_R1                         = 1510,
+    SPELL_HUNTER_SERPENT_STING_R1                  = 1978,
+    SPELL_HUNTER_RAPTOR_STRIKE_R1                  = 2973,
+    SPELL_HUNTER_STEADY_SHOT_R1                    = 3035,
+    SPELL_HUNTER_STEADY_SHOT_R2                    = 3036,
+    SPELL_HUNTER_STEADY_SHOT_R3                    = 3037,
+    SPELL_HUNTER_STEADY_SHOT_R4                    = 3038,
+    SPELL_HUNTER_ARCANE_SHOT_R1                    = 3044,
+    SPELL_HUNTER_VOLLEY_R2                         = 14294,
+    SPELL_HUNTER_VOLLEY_R3                         = 14295,
+    SPELL_HUNTER_RAPTOR_STRIKE_R2                  = 14260,
+    SPELL_HUNTER_RAPTOR_STRIKE_R3                  = 14261,
+    SPELL_HUNTER_RAPTOR_STRIKE_R4                  = 14262,
+    SPELL_HUNTER_RAPTOR_STRIKE_R5                  = 14263,
+    SPELL_HUNTER_RAPTOR_STRIKE_R6                  = 14264,
+    SPELL_HUNTER_RAPTOR_STRIKE_R7                  = 14265,
+    SPELL_HUNTER_RAPTOR_STRIKE_R8                  = 14266,
+    SPELL_HUNTER_ARCANE_SHOT_R2                    = 14281,
+    SPELL_HUNTER_ARCANE_SHOT_R3                    = 14282,
+    SPELL_HUNTER_ARCANE_SHOT_R4                    = 14283,
+    SPELL_HUNTER_ARCANE_SHOT_R5                    = 14284,
+    SPELL_HUNTER_ARCANE_SHOT_R6                    = 14285,
+    SPELL_HUNTER_ARCANE_SHOT_R7                    = 14286,
+    SPELL_HUNTER_ARCANE_SHOT_R8                    = 14287,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R1             = 13165,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R2             = 14318,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R3             = 14319,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R4             = 14320,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R5             = 14321,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R6             = 14322,
+    SPELL_HUNTER_AIMED_SHOT_R1                     = 19434,
+    SPELL_HUNTER_SWIFT_ASPECTS_R1                  = 19552,
+    SPELL_HUNTER_SWIFT_ASPECTS_R2                  = 19553,
+    SPELL_HUNTER_SWIFT_ASPECTS_R3                  = 19554,
+    SPELL_HUNTER_SWIFT_ASPECTS_R4                  = 19555,
+    SPELL_HUNTER_SWIFT_ASPECTS_R5                  = 19556,
+    SPELL_HUNTER_EYES_OF_THE_BEAST_TALENT_R1       = 19557,
+    SPELL_HUNTER_EYES_OF_THE_BEAST_TALENT_R2       = 19558,
+    SPELL_HUNTER_AIMED_SHOT_R2                     = 20900,
+    SPELL_HUNTER_AIMED_SHOT_R3                     = 20901,
+    SPELL_HUNTER_AIMED_SHOT_R4                     = 20902,
+    SPELL_HUNTER_AIMED_SHOT_R5                     = 20903,
+    SPELL_HUNTER_AIMED_SHOT_R6                     = 20904,
+    SPELL_HUNTER_IMPROVED_MEND_PET_DISPEL          = 24406,
+    SPELL_HUNTER_ASPECT_OF_THE_HAWK_R7             = 25296,
+    SPELL_HUNTER_AIMED_SHOT_R6_TURTLE              = 27632,
+    SPELL_HUNTER_STEADY_SHOT_R5                    = 3668,
+    SPELL_HUNTER_KILL_COMMAND_DAMAGE               = 41828,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R1             = 45650,
+    SPELL_HUNTER_EYES_OF_THE_BEAST_BOND_R1         = 45662,
+    SPELL_HUNTER_EYES_OF_THE_BEAST_BOND_R2         = 45663,
+    SPELL_HUNTER_STEADY_SHOT_R6                    = 45970,
+    SPELL_HUNTER_STEADY_SHOT_R7                    = 45972,
+    SPELL_HUNTER_STEADY_SHOT_R8                    = 45974,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R2             = 51496,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R3             = 51497,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R4             = 51498,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R5             = 51499,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R6             = 51500,
+    SPELL_HUNTER_ASPECT_OF_THE_WOLF_R7             = 51501,
+    SPELL_HUNTER_QUICK_STRIKES_R1                  = 51542,
+    SPELL_HUNTER_QUICK_STRIKES_R2                  = 51543,
+    SPELL_HUNTER_QUICK_STRIKES_R3                  = 51544,
+    SPELL_HUNTER_QUICK_STRIKES_R4                  = 51545,
+    SPELL_HUNTER_QUICK_STRIKES_R5                  = 51546,
+    SPELL_HUNTER_QUICK_SHOTS_R1                    = 51547,
+    SPELL_HUNTER_QUICK_SHOTS_R2                    = 51548,
+    SPELL_HUNTER_QUICK_SHOTS_R3                    = 51549,
+    SPELL_HUNTER_QUICK_SHOTS_R4                    = 51550,
+    SPELL_HUNTER_QUICK_SHOTS_R5                    = 51551,
+    SPELL_HUNTER_STINGING_NETTLE_R1                = 51579,
+    SPELL_HUNTER_STINGING_NETTLE_R2                = 51580,
+    SPELL_HUNTER_PIERCING_SHOTS                    = 51514,
+    SPELL_HUNTER_SCENT_OF_BLOOD                    = 52995,
+    SPELL_HUNTER_LOCK_AND_LOAD_AURA                = 52921,
+    SPELL_HUNTER_EXPLOSIVE_AMMUNITION              = 58109,
+    SPELL_HUNTER_POISONOUS_AMMUNITION              = 58110,
+    SPELL_HUNTER_ENCHANTED_AMMUNITION              = 58111,
+    SPELL_HUNTER_EXPLOSIVE_AMMUNITION_TRIGGER      = 58112,
+    SPELL_HUNTER_POISONOUS_AMMUNITION_TRIGGER      = 58113,
+    SPELL_HUNTER_ENCHANTED_AMMUNITION_TRIGGER      = 58114,
+};
+
 template <class T>
 SpellScript* GetSpellScript(SpellEntry const*)
 {
@@ -28,6 +113,73 @@ void RegisterAuraScript(char const* name, AuraScript* (*getter)(SpellEntry const
     script->Name = name;
     script->GetAuraScript = getter;
     script->RegisterSelf();
+}
+
+bool HasAspectOfTheWolf(Unit const* unit)
+{
+    return unit && (unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R1) ||
+        unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R2) ||
+        unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R3) ||
+        unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R4) ||
+        unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R5) ||
+        unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R6) ||
+        unit->HasAura(SPELL_HUNTER_ASPECT_OF_THE_WOLF_R7));
+}
+
+static constexpr float HUNTER_LOCK_AND_LOAD_LINE_WIDTH = 2.0f;
+
+struct HunterLineShotContext
+{
+    ObjectGuid casterGuid;
+    ObjectGuid targetGuid;
+    uint32 spellId;
+};
+
+thread_local std::vector<HunterLineShotContext> s_hunterLockAndLoadLineShots;
+
+bool IsAimedShot(SpellEntry const* spell)
+{
+    return spell && spell->IsFitToFamily<SPELLFAMILY_HUNTER, CF_HUNTER_AIMED_SHOT>();
+}
+
+bool IsSameHunterLineShot(HunterLineShotContext const& context, ObjectGuid const& casterGuid, ObjectGuid const& targetGuid, uint32 spellId)
+{
+    return context.casterGuid == casterGuid &&
+        context.targetGuid == targetGuid &&
+        context.spellId == spellId;
+}
+
+bool IsLockAndLoadLineShot(Unit const* caster, Unit const* target, SpellEntry const* spellInfo)
+{
+    if (!caster || !target || !spellInfo)
+        return false;
+
+    ObjectGuid const casterGuid = caster->GetObjectGuid();
+    ObjectGuid const targetGuid = target->GetObjectGuid();
+    uint32 const spellId = spellInfo->Id;
+    return std::any_of(s_hunterLockAndLoadLineShots.begin(), s_hunterLockAndLoadLineShots.end(),
+        [casterGuid, targetGuid, spellId](HunterLineShotContext const& context)
+        {
+            return IsSameHunterLineShot(context, casterGuid, targetGuid, spellId);
+        });
+}
+
+void PopLockAndLoadLineShot(Unit const* caster, Unit const* target, SpellEntry const* spellInfo)
+{
+    if (!caster || !target || !spellInfo)
+        return;
+
+    ObjectGuid const casterGuid = caster->GetObjectGuid();
+    ObjectGuid const targetGuid = target->GetObjectGuid();
+    uint32 const spellId = spellInfo->Id;
+    auto itr = std::find_if(s_hunterLockAndLoadLineShots.rbegin(), s_hunterLockAndLoadLineShots.rend(),
+        [casterGuid, targetGuid, spellId](HunterLineShotContext const& context)
+        {
+            return IsSameHunterLineShot(context, casterGuid, targetGuid, spellId);
+        });
+
+    if (itr != s_hunterLockAndLoadLineShots.rend())
+        s_hunterLockAndLoadLineShots.erase(std::next(itr).base());
 }
 
 void ApplyStingingNettle(Spell* spell);
@@ -150,6 +302,442 @@ struct spell_hunter_stinging_nettle_fire_trap : public SpellScript
     }
 };
 
+struct spell_hunter_trap : public SpellScript
+{
+    bool OnCanCastNonCombatSpellInCombat(Spell* spell) const override
+    {
+        return spell->m_casterUnit && spell->m_casterUnit->HasAura(51586);
+    }
+};
+
+struct spell_hunter_lacerate : public SpellScript
+{
+    static bool IsAttackingFromSide(Unit const* caster, Unit const* target)
+    {
+        return caster && target &&
+            !target->HasInArc(caster, M_PI_F / 2.0f) &&
+            !target->HasInArc(caster, M_PI_F / 2.0f, M_PI_F);
+    }
+
+    void OnEffectDamageCalculate(Spell* spell, SpellEffectIndex effIdx, float& damage) const override
+    {
+        if (effIdx != EFFECT_INDEX_0 || !spell->m_casterUnit)
+            return;
+
+        Unit* target = spell->GetUnitTarget();
+        if (!target)
+            return;
+
+        damage = spell->m_casterUnit->GetTotalAttackPowerValue(BASE_ATTACK) * 0.40f;
+        if (IsAttackingFromSide(spell->m_casterUnit, target))
+            damage *= 1.15f;
+    }
+
+    void OnAfterHit(Spell* spell) const override
+    {
+        if (!spell->m_casterUnit)
+            return;
+
+        Unit* target = spell->GetUnitTarget();
+        if (!target || !target->IsAlive())
+            return;
+
+        int32 const damage = int32(spell->GetTotalEffectDamage());
+        if (damage <= 0)
+            return;
+
+        SpellEntry const* bleedInfo = sSpellMgr.GetSpellEntry(48050);
+        if (!bleedInfo)
+            return;
+
+        uint32 tickCount = 1;
+        int32 const duration = bleedInfo->CalculateDuration(spell->m_casterUnit, target);
+        if (duration > 0 && bleedInfo->EffectAmplitude[EFFECT_INDEX_0])
+            tickCount = std::max<uint32>(1, uint32(duration) / bleedInfo->EffectAmplitude[EFFECT_INDEX_0]);
+
+        int32 const tickDamage = damage * 20 / 100 / int32(tickCount);
+        if (tickDamage <= 0)
+            return;
+
+        spell->m_casterUnit->CastCustomSpell(target, 48050, &tickDamage, nullptr, nullptr, true);
+    }
+};
+
+struct spell_hunter_bestial_wrath : public SpellScript
+{
+    void OnEffectExecuted(Spell* spell, SpellEffectIndex effIdx) const override
+    {
+        if (effIdx != EFFECT_INDEX_0 || !spell || !spell->m_casterUnit)
+            return;
+
+        Unit* pet = spell->m_casterUnit->GetPet();
+        if (!pet)
+            return;
+
+        static constexpr int32 BESTIAL_WRATH_DURATION = 18 * IN_MILLISECONDS;
+
+        SpellAuraHolder* holder = pet->GetSpellAuraHolder(SPELL_HUNTER_SCENT_OF_BLOOD, spell->m_casterUnit->GetObjectGuid());
+        if (!holder)
+            holder = pet->GetSpellAuraHolder(SPELL_HUNTER_SCENT_OF_BLOOD);
+        if (!holder)
+            return;
+
+        holder->SetAuraMaxDuration(BESTIAL_WRATH_DURATION);
+        holder->SetAuraDuration(BESTIAL_WRATH_DURATION);
+    }
+};
+
+struct spell_hunter_kill_command : public SpellScript
+{
+    static Unit* GetKillCommandTarget(Spell* spell, Player* hunter, Pet* pet)
+    {
+        if (Unit* target = spell->m_targets.getUnitTarget())
+            if (target != pet && target->IsAlive() && hunter->IsValidAttackTarget(target))
+                return target;
+
+        if (Unit* target = hunter->GetSelectedUnit())
+            if (target->IsAlive() && hunter->IsValidAttackTarget(target))
+                return target;
+
+        if (Unit* target = pet->GetVictim())
+            if (target->IsAlive() && hunter->IsValidAttackTarget(target))
+                return target;
+
+        return nullptr;
+    }
+
+    SpellCastResult OnCheckCast(Spell* spell, bool /*strict*/) const override
+    {
+        Player* hunter = spell && spell->m_casterUnit ? spell->m_casterUnit->ToPlayer() : nullptr;
+        if (!hunter)
+            return SPELL_FAILED_BAD_TARGETS;
+
+        Pet* pet = hunter->GetPet();
+        if (!pet || !pet->IsAlive())
+            return SPELL_FAILED_NO_PET;
+
+        if (!GetKillCommandTarget(spell, hunter, pet))
+            return SPELL_FAILED_BAD_TARGETS;
+
+        return SPELL_CAST_OK;
+    }
+
+    bool OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const override
+    {
+        if (effIdx != EFFECT_INDEX_0 || !spell || !spell->m_casterUnit)
+            return false;
+
+        Player* hunter = spell->m_casterUnit->ToPlayer();
+        Pet* pet = hunter ? hunter->GetPet() : nullptr;
+        if (!hunter || !pet || !pet->IsAlive())
+            return false;
+
+        Unit* target = GetKillCommandTarget(spell, hunter, pet);
+        if (!target)
+            return false;
+
+        pet->CastSpell(target, SPELL_HUNTER_KILL_COMMAND_DAMAGE, true);
+        return false;
+    }
+};
+
+struct spell_hunter_kill_command_damage : public SpellScript
+{
+    void OnEffectDamageCalculate(Spell* spell, SpellEffectIndex /*effIdx*/, float& damage) const override
+    {
+        if (!spell || !spell->m_casterUnit)
+            return;
+
+        damage = spell->m_casterUnit->GetTotalAttackPowerValue(BASE_ATTACK) * 0.80f;
+    }
+};
+
+struct spell_hunter_volley : public AuraScript
+{
+    void OnPeriodicDamageCalculateAmount(Aura* aura, float& amount) override
+    {
+        Unit* caster = aura->GetCaster();
+        if (!caster)
+            return;
+
+        float coefficient = 0.0f;
+        switch (aura->GetId())
+        {
+            case SPELL_HUNTER_VOLLEY_R1: coefficient = 0.04f; break;
+            case SPELL_HUNTER_VOLLEY_R2: coefficient = 0.05f; break;
+            case SPELL_HUNTER_VOLLEY_R3: coefficient = 0.06f; break;
+            default:
+                return;
+        }
+
+        amount += caster->GetTotalAttackPowerValue(RANGED_ATTACK) * coefficient;
+    }
+};
+
+struct spell_hunter_experimental_ammunition : public AuraScript
+{
+    uint32 m_nextState = SPELL_HUNTER_EXPLOSIVE_AMMUNITION;
+
+    std::optional<SpellProcEventTriggerCheck> OnCheckProc(Unit const* owner, Unit* victim, SpellAuraHolder* /*holder*/, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 procExtra, WeaponAttackType /*attType*/, bool isVictim) override
+    {
+        if (!owner || isVictim || !victim || !victim->IsAlive())
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        if (!IsAimedShot(procSpell))
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        return (procExtra & (PROC_EX_NORMAL_HIT | PROC_EX_CRITICAL_HIT)) ? SPELL_PROC_TRIGGER_OK : SPELL_PROC_TRIGGER_FAILED;
+    }
+
+    std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* victim, uint32 damage, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/) override
+    {
+        if (!owner || !victim || !victim->IsAlive() || !damage)
+            return SPELL_AURA_PROC_FAILED;
+
+        uint32 nextState = m_nextState;
+        if (owner->HasAura(SPELL_HUNTER_EXPLOSIVE_AMMUNITION))
+            nextState = SPELL_HUNTER_POISONOUS_AMMUNITION;
+        else if (owner->HasAura(SPELL_HUNTER_POISONOUS_AMMUNITION))
+            nextState = SPELL_HUNTER_ENCHANTED_AMMUNITION;
+        else if (owner->HasAura(SPELL_HUNTER_ENCHANTED_AMMUNITION))
+            nextState = SPELL_HUNTER_EXPLOSIVE_AMMUNITION;
+
+        int32 elementalDamage = damage * std::max(0, aura->GetModifier()->m_amount + 1) / 100;
+        if (!elementalDamage)
+            return SPELL_AURA_PROC_FAILED;
+
+        owner->RemoveAurasDueToSpell(SPELL_HUNTER_EXPLOSIVE_AMMUNITION);
+        owner->RemoveAurasDueToSpell(SPELL_HUNTER_POISONOUS_AMMUNITION);
+        owner->RemoveAurasDueToSpell(SPELL_HUNTER_ENCHANTED_AMMUNITION);
+        owner->CastCustomSpell(victim, nextState, &elementalDamage, nullptr, nullptr, true, nullptr, aura);
+        switch (nextState)
+        {
+            case SPELL_HUNTER_EXPLOSIVE_AMMUNITION:
+                m_nextState = SPELL_HUNTER_POISONOUS_AMMUNITION;
+                break;
+            case SPELL_HUNTER_POISONOUS_AMMUNITION:
+                m_nextState = SPELL_HUNTER_ENCHANTED_AMMUNITION;
+                break;
+            case SPELL_HUNTER_ENCHANTED_AMMUNITION:
+            default:
+                m_nextState = SPELL_HUNTER_EXPLOSIVE_AMMUNITION;
+                break;
+        }
+        return SPELL_AURA_PROC_OK;
+    }
+};
+
+struct spell_hunter_experimental_ammunition_trigger : public SpellScript
+{
+    void OnSuccessfulFinish(Spell* spell) const override
+    {
+        if (!spell || !spell->m_casterUnit)
+            return;
+
+        uint32 stateSpellId = 0;
+        switch (spell->m_spellInfo->Id)
+        {
+            case SPELL_HUNTER_EXPLOSIVE_AMMUNITION_TRIGGER:
+                stateSpellId = SPELL_HUNTER_EXPLOSIVE_AMMUNITION;
+                break;
+            case SPELL_HUNTER_POISONOUS_AMMUNITION_TRIGGER:
+                stateSpellId = SPELL_HUNTER_POISONOUS_AMMUNITION;
+                break;
+            case SPELL_HUNTER_ENCHANTED_AMMUNITION_TRIGGER:
+                stateSpellId = SPELL_HUNTER_ENCHANTED_AMMUNITION;
+                break;
+            default:
+                break;
+        }
+        if (!stateSpellId)
+            return;
+
+        Unit* caster = spell->m_casterUnit;
+        caster->m_Events.AddLambdaEventAtOffset([caster, stateSpellId]()
+        {
+            caster->RemoveAurasDueToSpell(stateSpellId);
+        }, 1);
+    }
+};
+
+struct spell_hunter_lock_and_load : public AuraScript
+{
+    std::optional<SpellProcEventTriggerCheck> OnCheckProc(Unit const* owner, Unit* victim, SpellAuraHolder* /*holder*/, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procExtra*/, WeaponAttackType /*attType*/, bool isVictim) override
+    {
+        if (!owner || isVictim || !victim || !victim->IsAlive())
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        return std::nullopt;
+    }
+
+    std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* /*victim*/, uint32 /*damage*/, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/) override
+    {
+        if (!owner || !aura)
+            return SPELL_AURA_PROC_FAILED;
+
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R1, true);
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R2, true);
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R3, true);
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R4, true);
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R5, true);
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R6, true);
+        owner->RemoveSpellCooldown(SPELL_HUNTER_AIMED_SHOT_R6_TURTLE, true);
+        owner->CastSpell(owner, SPELL_HUNTER_LOCK_AND_LOAD_AURA, true, nullptr, aura);
+        return SPELL_AURA_PROC_OK;
+    }
+};
+
+struct spell_hunter_aimed_shot : public SpellScript
+{
+    mutable std::vector<ObjectGuid> m_lockAndLoadLineTargets;
+    mutable bool m_isLockAndLoadLineShot = false;
+
+    std::optional<uint32> OnCalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spell* spell, Item* /*castItem*/) const override
+    {
+        if (m_isLockAndLoadLineShot)
+            return 0;
+
+        Unit* target = spell ? spell->m_targets.getUnitTarget() : nullptr;
+        if (IsLockAndLoadLineShot(caster, target, spellInfo))
+            return 0;
+
+        return std::nullopt;
+    }
+
+    void OnSuccessfulStart(Spell* spell) const override
+    {
+        m_lockAndLoadLineTargets.clear();
+        m_isLockAndLoadLineShot = false;
+
+        if (!spell->m_casterUnit || !IsAimedShot(spell->m_spellInfo))
+            return;
+
+        if (spell->IsTriggered())
+        {
+            Unit* target = spell->m_targets.getUnitTarget();
+            if (IsLockAndLoadLineShot(spell->m_casterUnit, target, spell->m_spellInfo))
+            {
+                m_isLockAndLoadLineShot = true;
+                PopLockAndLoadLineShot(spell->m_casterUnit, target, spell->m_spellInfo);
+            }
+
+            return;
+        }
+
+        if (!spell->m_casterUnit->HasAura(SPELL_HUNTER_LOCK_AND_LOAD_AURA))
+            return;
+
+        Unit* primaryTarget = spell->m_targets.getUnitTarget();
+        if (!primaryTarget || !primaryTarget->IsAlive())
+            return;
+
+        float const searchRange = spell->m_casterUnit->GetDistance(primaryTarget) + HUNTER_LOCK_AND_LOAD_LINE_WIDTH;
+        std::list<Unit*> targets;
+        MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck check(spell->m_casterUnit, spell->m_casterUnit, searchRange);
+        MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, check);
+        Cell::VisitAllObjects(spell->m_casterUnit, searcher, searchRange);
+
+        for (Unit* target : targets)
+        {
+            if (!target || target == primaryTarget || target == spell->m_casterUnit)
+                continue;
+
+            if (!spell->m_casterUnit->IsValidAttackTarget(target) || !spell->m_casterUnit->IsWithinLOSInMap(target))
+                continue;
+
+            float const casterX = spell->m_casterUnit->GetPositionX();
+            float const casterY = spell->m_casterUnit->GetPositionY();
+            float const targetX = primaryTarget->GetPositionX();
+            float const targetY = primaryTarget->GetPositionY();
+            float const unitX = target->GetPositionX();
+            float const unitY = target->GetPositionY();
+
+            float const lineX = targetX - casterX;
+            float const lineY = targetY - casterY;
+            float const lineLengthSq = lineX * lineX + lineY * lineY;
+            if (lineLengthSq <= 0.0f)
+                continue;
+
+            float const unitLineX = unitX - casterX;
+            float const unitLineY = unitY - casterY;
+            float const projection = (unitLineX * lineX + unitLineY * lineY) / lineLengthSq;
+            if (projection <= 0.0f || projection >= 1.0f)
+                continue;
+
+            float const closestX = casterX + projection * lineX;
+            float const closestY = casterY + projection * lineY;
+            float const distanceX = unitX - closestX;
+            float const distanceY = unitY - closestY;
+            if (distanceX * distanceX + distanceY * distanceY > HUNTER_LOCK_AND_LOAD_LINE_WIDTH * HUNTER_LOCK_AND_LOAD_LINE_WIDTH)
+                continue;
+
+            m_lockAndLoadLineTargets.push_back(target->GetObjectGuid());
+        }
+    }
+
+    void OnCast(Spell* spell) const override
+    {
+        if (m_lockAndLoadLineTargets.empty() || !spell->m_casterUnit || !IsAimedShot(spell->m_spellInfo))
+            return;
+
+        std::vector<ObjectGuid> const lineTargets = m_lockAndLoadLineTargets;
+        m_lockAndLoadLineTargets.clear();
+
+        for (ObjectGuid const& targetGuid : lineTargets)
+        {
+            Unit* target = ObjectAccessor::GetUnit(*spell->m_casterUnit, targetGuid);
+            if (!target || !target->IsAlive() || !spell->m_casterUnit->IsValidAttackTarget(target))
+                continue;
+
+            s_hunterLockAndLoadLineShots.push_back({spell->m_casterUnit->GetObjectGuid(), target->GetObjectGuid(), spell->m_spellInfo->Id});
+            spell->m_casterUnit->CastSpell(target, spell->m_spellInfo, true);
+            PopLockAndLoadLineShot(spell->m_casterUnit, target, spell->m_spellInfo);
+        }
+    }
+
+    bool OnTakeAmmo(Spell* /*spell*/) const override
+    {
+        return !m_isLockAndLoadLineShot;
+    }
+};
+
+struct spell_hunter_piercing_shots : public AuraScript
+{
+    std::optional<SpellProcEventTriggerCheck> OnCheckProc(Unit const* owner, Unit* victim, SpellAuraHolder* /*holder*/, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procExtra*/, WeaponAttackType /*attType*/, bool isVictim) override
+    {
+        if (!owner || isVictim || !victim || !victim->IsAlive())
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        return std::nullopt;
+    }
+
+    std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* victim, uint32 damage, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/) override
+    {
+        if (!owner || !victim || !victim->IsAlive() || !damage || !aura)
+            return SPELL_AURA_PROC_FAILED;
+
+        int32 const percent = std::max(0, aura->GetModifier()->m_amount);
+        if (!percent)
+            return SPELL_AURA_PROC_FAILED;
+
+        uint32 tickCount = 1;
+        if (SpellEntry const* piercingShots = sSpellMgr.GetSpellEntry(SPELL_HUNTER_PIERCING_SHOTS))
+        {
+            int32 const duration = piercingShots->CalculateDuration(owner, victim);
+            if (duration > 0 && piercingShots->EffectAmplitude[EFFECT_INDEX_0])
+                tickCount = std::max<uint32>(1, uint32(duration) / piercingShots->EffectAmplitude[EFFECT_INDEX_0]);
+        }
+
+        int32 const totalDamage = int32(damage * percent / 100);
+        int32 const tickDamage = totalDamage / int32(tickCount);
+        if (tickDamage <= 0)
+            return SPELL_AURA_PROC_FAILED;
+
+        owner->CastCustomSpell(victim, SPELL_HUNTER_PIERCING_SHOTS, &tickDamage, nullptr, nullptr, true, nullptr, aura);
+        return SPELL_AURA_PROC_OK;
+    }
+};
+
 struct spell_hunter_improved_mend_pet : public AuraScript
 {
     std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* victim, uint32 /*damage*/, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/) override
@@ -160,8 +748,214 @@ struct spell_hunter_improved_mend_pet : public AuraScript
         if (!roll_chance_i(aura->GetModifier()->m_amount))
             return SPELL_AURA_PROC_FAILED;
 
-        owner->CastSpell(victim, 24406, true, nullptr, aura);
+        owner->CastSpell(victim, SPELL_HUNTER_IMPROVED_MEND_PET_DISPEL, true, nullptr, aura);
         return SPELL_AURA_PROC_OK;
+    }
+};
+
+struct spell_hunter_swift_aspects : public AuraScript
+{
+    std::optional<SpellProcEventTriggerCheck> OnCheckProc(Unit const* owner, Unit* /*victim*/, SpellAuraHolder* /*holder*/, SpellEntry const* /*procSpell*/, uint32 procFlag, uint32 /*procExtra*/, WeaponAttackType attType, bool isVictim) override
+    {
+        if (!owner || isVictim)
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        bool const hasHawkAspect = owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R1) ||
+            owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R2) ||
+            owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R3) ||
+            owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R4) ||
+            owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R5) ||
+            owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R6) ||
+            owner->HasAura(SPELL_HUNTER_ASPECT_OF_THE_HAWK_R7);
+
+        if ((procFlag & PROC_FLAG_DEAL_RANGED_ATTACK) && attType == RANGED_ATTACK && hasHawkAspect)
+            return std::nullopt;
+
+        if ((procFlag & PROC_FLAG_DEAL_MELEE_SWING) && (attType == BASE_ATTACK || attType == OFF_ATTACK) && HasAspectOfTheWolf(owner))
+            return std::nullopt;
+
+        return SPELL_PROC_TRIGGER_FAILED;
+    }
+
+    std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* /*victim*/, uint32 /*damage*/, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 procFlag, uint32 /*procEx*/, uint32 /*cooldown*/) override
+    {
+        if (!owner || !aura)
+            return SPELL_AURA_PROC_FAILED;
+
+        uint32 rank = 0;
+        switch (aura->GetId())
+        {
+            case SPELL_HUNTER_SWIFT_ASPECTS_R1: rank = 0; break;
+            case SPELL_HUNTER_SWIFT_ASPECTS_R2: rank = 1; break;
+            case SPELL_HUNTER_SWIFT_ASPECTS_R3: rank = 2; break;
+            case SPELL_HUNTER_SWIFT_ASPECTS_R4: rank = 3; break;
+            case SPELL_HUNTER_SWIFT_ASPECTS_R5: rank = 4; break;
+            default:
+                return SPELL_AURA_PROC_FAILED;
+        }
+
+        static constexpr uint32 quickShots[] =
+        {
+            SPELL_HUNTER_QUICK_SHOTS_R1,
+            SPELL_HUNTER_QUICK_SHOTS_R2,
+            SPELL_HUNTER_QUICK_SHOTS_R3,
+            SPELL_HUNTER_QUICK_SHOTS_R4,
+            SPELL_HUNTER_QUICK_SHOTS_R5,
+        };
+        static constexpr uint32 quickStrikes[] =
+        {
+            SPELL_HUNTER_QUICK_STRIKES_R1,
+            SPELL_HUNTER_QUICK_STRIKES_R2,
+            SPELL_HUNTER_QUICK_STRIKES_R3,
+            SPELL_HUNTER_QUICK_STRIKES_R4,
+            SPELL_HUNTER_QUICK_STRIKES_R5,
+        };
+
+        if (procFlag & PROC_FLAG_DEAL_RANGED_ATTACK)
+        {
+            owner->CastSpell(owner, quickShots[rank], true, nullptr, aura);
+            return SPELL_AURA_PROC_OK;
+        }
+
+        if (procFlag & PROC_FLAG_DEAL_MELEE_SWING)
+        {
+            owner->CastSpell(owner, quickStrikes[rank], true, nullptr, aura);
+            return SPELL_AURA_PROC_OK;
+        }
+
+        return SPELL_AURA_PROC_FAILED;
+    }
+};
+
+struct spell_hunter_improved_primal_aspects : public AuraScript
+{
+    std::optional<SpellProcEventTriggerCheck> OnCheckProc(Unit const* owner, Unit* /*victim*/, SpellAuraHolder* /*holder*/, SpellEntry const* /*procSpell*/, uint32 procFlag, uint32 /*procExtra*/, WeaponAttackType /*attType*/, bool isVictim) override
+    {
+        if (!owner || isVictim)
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        if (!(procFlag & (PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_DEAL_MELEE_ABILITY)))
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        if (!HasAspectOfTheWolf(owner))
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        return std::nullopt;
+    }
+
+    std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* /*victim*/, uint32 damage, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/) override
+    {
+        if (!owner || !aura || !damage)
+            return SPELL_AURA_PROC_FAILED;
+
+        if (aura->GetEffIndex() != EFFECT_INDEX_1 || aura->GetModifier()->m_auraname != SPELL_AURA_DUMMY)
+            return SPELL_AURA_PROC_CANT_TRIGGER;
+
+        uint32 const heal = damage * uint32(aura->GetModifier()->m_amount) / 100;
+        if (!heal)
+            return SPELL_AURA_PROC_FAILED;
+
+        owner->DealHeal(owner, heal, aura->GetSpellProto());
+        return SPELL_AURA_PROC_OK;
+    }
+};
+
+struct spell_hunter_alone_against_the_world : public AuraScript
+{
+    void OnAuraInit(Aura* aura) override
+    {
+        if (aura && aura->GetEffIndex() == EFFECT_INDEX_1 && aura->GetModifier()->periodictime)
+            aura->SetPeriodicTimer(aura->GetModifier()->periodictime);
+    }
+
+    static void SyncDamageAura(Aura* aura)
+    {
+        if (!aura)
+            return;
+
+        Player* player = aura->GetTarget()->ToPlayer();
+        SpellAuraHolder* holder = aura->GetHolder();
+        Aura* damageAura = holder ? holder->GetAuraByEffectIndex(EFFECT_INDEX_0) : nullptr;
+        if (!player || !damageAura)
+            return;
+
+        bool const shouldApplyDamage = !player->GetPet();
+        if (damageAura->IsApplied() != shouldApplyDamage)
+            damageAura->ApplyModifier(shouldApplyDamage, true);
+    }
+
+    void OnAfterApply(Aura* aura, bool apply) override
+    {
+        if (apply)
+            SyncDamageAura(aura);
+    }
+
+    void OnPeriodicDummy(Aura* aura) override
+    {
+        if (!aura || aura->GetEffIndex() != EFFECT_INDEX_1)
+            return;
+
+        SyncDamageAura(aura);
+    }
+};
+
+struct spell_hunter_strike_together_damage : public SpellScript
+{
+    void OnEffectDamageCalculate(Spell* spell, SpellEffectIndex /*effIdx*/, float& damage) const override
+    {
+        if (!spell || !spell->m_casterUnit)
+            return;
+
+        Player* hunter = ToPlayer(spell->GetAffectiveCaster());
+        if (!hunter)
+            hunter = spell->m_casterUnit->GetCharmerOrOwnerPlayerOrPlayerItself();
+        if (!hunter || hunter->GetClass() != CLASS_HUNTER)
+            return;
+
+        damage = hunter->GetTotalAttackPowerValue(BASE_ATTACK) * 0.20f;
+    }
+};
+
+struct spell_hunter_coordinated_assault : public AuraScript
+{
+    std::optional<SpellProcEventTriggerCheck> OnCheckProc(Unit const* owner, Unit* victim, SpellAuraHolder* /*holder*/, SpellEntry const* procSpell, uint32 /*procFlag*/, uint32 /*procExtra*/, WeaponAttackType /*attType*/, bool isVictim) override
+    {
+        if (!owner || isVictim || !victim || !victim->IsAlive())
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        if (!procSpell || procSpell->SpellFamilyName != SPELLFAMILY_HUNTER)
+            return SPELL_PROC_TRIGGER_FAILED;
+
+        switch (procSpell->Id)
+        {
+            case SPELL_HUNTER_RAPTOR_STRIKE_R1:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R2:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R3:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R4:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R5:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R6:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R7:
+            case SPELL_HUNTER_RAPTOR_STRIKE_R8:
+            case SPELL_HUNTER_ARCANE_SHOT_R1:
+            case SPELL_HUNTER_ARCANE_SHOT_R2:
+            case SPELL_HUNTER_ARCANE_SHOT_R3:
+            case SPELL_HUNTER_ARCANE_SHOT_R4:
+            case SPELL_HUNTER_ARCANE_SHOT_R5:
+            case SPELL_HUNTER_ARCANE_SHOT_R6:
+            case SPELL_HUNTER_ARCANE_SHOT_R7:
+            case SPELL_HUNTER_ARCANE_SHOT_R8:
+            case SPELL_HUNTER_STEADY_SHOT_R1:
+            case SPELL_HUNTER_STEADY_SHOT_R2:
+            case SPELL_HUNTER_STEADY_SHOT_R3:
+            case SPELL_HUNTER_STEADY_SHOT_R4:
+            case SPELL_HUNTER_STEADY_SHOT_R5:
+            case SPELL_HUNTER_STEADY_SHOT_R6:
+            case SPELL_HUNTER_STEADY_SHOT_R7:
+            case SPELL_HUNTER_STEADY_SHOT_R8:
+                return std::nullopt;
+            default:
+                return SPELL_PROC_TRIGGER_FAILED;
+        }
     }
 };
 
@@ -173,10 +967,10 @@ void ApplyStingingNettle(Spell* spell)
         return;
 
     uint32 nettleSpellId = 0;
-    if (caster->HasSpell(51580))
-        nettleSpellId = 51580;
-    else if (caster->HasSpell(51579))
-        nettleSpellId = 51579;
+    if (caster->HasSpell(SPELL_HUNTER_STINGING_NETTLE_R2))
+        nettleSpellId = SPELL_HUNTER_STINGING_NETTLE_R2;
+    else if (caster->HasSpell(SPELL_HUNTER_STINGING_NETTLE_R1))
+        nettleSpellId = SPELL_HUNTER_STINGING_NETTLE_R1;
 
     if (!nettleSpellId)
         return;
@@ -186,9 +980,9 @@ void ApplyStingingNettle(Spell* spell)
         durationPct = nettleInfo->CalculateSimpleValue(EFFECT_INDEX_0);
 
     if (durationPct <= 0)
-        durationPct = nettleSpellId == 51580 ? 40 : 20;
+        durationPct = nettleSpellId == SPELL_HUNTER_STINGING_NETTLE_R2 ? 40 : 20;
 
-    uint32 const serpentFirstRank = sSpellMgr.GetFirstSpellInChain(1978);
+    uint32 const serpentFirstRank = sSpellMgr.GetFirstSpellInChain(SPELL_HUNTER_SERPENT_STING_R1);
     uint32 serpentId = caster->HasSpell(serpentFirstRank) ? serpentFirstRank : 0;
 
     struct HighestSerpentWorker
@@ -251,19 +1045,19 @@ struct spell_hunter_eyes_of_the_beast : public AuraScript
         if (!caster)
             return;
 
-        if (caster->HasSpell(19557))
+        if (caster->HasSpell(SPELL_HUNTER_EYES_OF_THE_BEAST_TALENT_R1))
         {
             if (apply)
-                caster->CastSpell(caster, 45662, true);
+                caster->CastSpell(caster, SPELL_HUNTER_EYES_OF_THE_BEAST_BOND_R1, true);
             else
-                caster->RemoveAurasDueToSpell(45662);
+                caster->RemoveAurasDueToSpell(SPELL_HUNTER_EYES_OF_THE_BEAST_BOND_R1);
         }
-        else if (caster->HasSpell(19558))
+        else if (caster->HasSpell(SPELL_HUNTER_EYES_OF_THE_BEAST_TALENT_R2))
         {
             if (apply)
-                caster->CastSpell(caster, 45663, true);
+                caster->CastSpell(caster, SPELL_HUNTER_EYES_OF_THE_BEAST_BOND_R2, true);
             else
-                caster->RemoveAurasDueToSpell(45663);
+                caster->RemoveAurasDueToSpell(SPELL_HUNTER_EYES_OF_THE_BEAST_BOND_R2);
         }
     }
 };
@@ -277,7 +1071,23 @@ void AddSC_hunter_spell_scripts()
     RegisterSpellScript("spell_hunter_counterattack", &GetSpellScript<spell_hunter_counterattack>);
     RegisterSpellScript("spell_hunter_mongoose_bite", &GetSpellScript<spell_hunter_mongoose_bite>);
     RegisterSpellScript("spell_hunter_stinging_nettle_fire_trap", &GetSpellScript<spell_hunter_stinging_nettle_fire_trap>);
+    RegisterSpellScript("spell_hunter_trap", &GetSpellScript<spell_hunter_trap>);
+    RegisterSpellScript("spell_hunter_lacerate", &GetSpellScript<spell_hunter_lacerate>);
+    RegisterSpellScript("spell_hunter_bestial_wrath", &GetSpellScript<spell_hunter_bestial_wrath>);
+    RegisterSpellScript("spell_hunter_kill_command", &GetSpellScript<spell_hunter_kill_command>);
+    RegisterSpellScript("spell_hunter_kill_command_damage", &GetSpellScript<spell_hunter_kill_command_damage>);
+    RegisterSpellScript("spell_hunter_strike_together_damage", &GetSpellScript<spell_hunter_strike_together_damage>);
+    RegisterSpellScript("spell_hunter_experimental_ammunition_trigger", &GetSpellScript<spell_hunter_experimental_ammunition_trigger>);
+    RegisterAuraScript("spell_hunter_coordinated_assault", &GetAuraScript<spell_hunter_coordinated_assault>);
+    RegisterAuraScript("spell_hunter_volley", &GetAuraScript<spell_hunter_volley>);
+    RegisterAuraScript("spell_hunter_experimental_ammunition", &GetAuraScript<spell_hunter_experimental_ammunition>);
+    RegisterAuraScript("spell_hunter_lock_and_load", &GetAuraScript<spell_hunter_lock_and_load>);
+    RegisterSpellScript("spell_hunter_aimed_shot", &GetSpellScript<spell_hunter_aimed_shot>);
+    RegisterAuraScript("spell_hunter_piercing_shots", &GetAuraScript<spell_hunter_piercing_shots>);
     RegisterAuraScript("spell_hunter_improved_mend_pet", &GetAuraScript<spell_hunter_improved_mend_pet>);
+    RegisterAuraScript("spell_hunter_swift_aspects", &GetAuraScript<spell_hunter_swift_aspects>);
+    RegisterAuraScript("spell_hunter_improved_primal_aspects", &GetAuraScript<spell_hunter_improved_primal_aspects>);
+    RegisterAuraScript("spell_hunter_alone_against_the_world", &GetAuraScript<spell_hunter_alone_against_the_world>);
     RegisterAuraScript("spell_hunter_frost_trap_aura", &GetAuraScript<spell_hunter_frost_trap_aura>);
     RegisterAuraScript("spell_hunter_eyes_of_the_beast", &GetAuraScript<spell_hunter_eyes_of_the_beast>);
 }


### PR DESCRIPTION
Volley - Added Ranged AP Scaling
Trueshot Aura - Fixes Aura Types 221/222 only affecting melee attack power Swift Aspects - Implemented
Improved Primal Aspects - Added Leech
Coordinated Assault - Added aura script to gate proc and proc event to add 3 second cooldown Cannot easily gate this entirely with spell_proc_event since the family masks are not unique for the trigger spells Bestial Discipline - Added spell_affect mask for cooldown reduction Bestial Wrath - Added 18 second override for Scent of Blood Bestial Precision - Added pet weapon skill increase Kill Command - Implemented via SpellScript system, will do another pass to try to return it to the data driven spell script system Endless Quiver - Added Steady Shot mask
Efficiency - Added Steady Shot mask
Hawk Eye - Added Steady Shot mask
Improved Marksmanship - Added Steady Shot mask
Experimental Ammunition - Implemented
Piercing Shots - Fixed damage calc and proc gating Lock and Load - Implemented
Resourcefulness - Fixed mask to include melee abilities Savage Strikes - Added Carve and Lacerate masks
Planning Ahead - Implemented
Hunter Traps - Fixed the cannot be used in combat attribute Went through historical data and for some reason the client side of these spells does not have this attribute, but the server side spell_template entries did Settings these through spell_mod to keep the spell_template matching the client data, even though that's now how it was in 1.17.1 Lacerate - Implemented, fixed stacking with immolation trap, serpent sting, and poison spit Trap Master - Fixed fire trap damage increase
Aspect of the Wolf - Removed old ranged ability block Untamed Trapper - Implemented
Poison Spit - Added 25% SP scaling, fixed stacking with traps Trueshot Aura - Fixes stacking with Hunter Aspects and missing ranged AP component
