### PR TITLE
Fix Croak Cannon toy collection mapping

### DIFF
--- a/sql/wip_updates/collection_toy.sql
+++ b/sql/wip_updates/collection_toy.sql
@@ -1,0 +1,1 @@
+INSERT IGNORE INTO `collection_toy` (`itemId`, `spellId`) VALUES (7013, 47107);


### PR DESCRIPTION
Closes #384 

## Changes

* Add the missing `collection_toy` mapping for Croak Cannon item `7013` to spell `47107`.
* Use `INSERT IGNORE` so the update is safe if the mapping already exists.

## Testing

Tested on an existing Tortoise-WoW 1.18.1 database where using Croak Cannon played the cast effect but did not consume the item or add the toy to the collection.

After inserting `(7013, 47107)` into `collection_toy` and restarting `mangosd`, the item was consumed correctly and Croak Cannon was added to the Toy Collection.