### PR TITLE
Fix BG buff pads (Berserking/Speed/Restoration) never triggering

### DIFF
--- a/src/game/Objects/GameObject.cpp
+++ b/src/game/Objects/GameObject.cpp
@@ -481,8 +481,23 @@ void GameObject::Update(uint32 update_diff, uint32 /*p_time*/)
                             if (m_respawnTime > 0)
                                 break;
 
-                            // battlegrounds gameobjects has data2 == 0 && data5 == 3
-                            radius = float(goInfo->trap.cooldown);
+                            // battlegrounds gameobjects has data2 == 0 && data5 == 3. data5
+                            // (trap.cooldown) is the intended reuse timer between casts, not
+                            // a trigger radius - it's used again further below to set
+                            // m_cooldownTime, unrelated to this substitution. Reusing that
+                            // same "3" as the activation radius made BG buff pads (WSG
+                            // Berserking/Speed/Restoration, and anything else on this same
+                            // data2==0/data5==3 pattern) require standing within 3 yards,
+                            // which players and bots alike routinely missed by a fraction of
+                            // a yard while fighting/moving near the pad - confirmed live via
+                            // temporary sampled logging in this exact search: closest
+                            // recorded miss was 3.24yd, 0.24 over the old 3.0yd radius, with
+                            // dozens of other near-misses in the 3-10yd band and never a
+                            // single successful trigger across ~20 minutes/923 samples on a
+                            // live WSG match. A fixed, dedicated radius replaces the
+                            // accidental reuse of the cooldown value; trap.cooldown still
+                            // governs the reuse timer exactly as before, untouched.
+                            radius = 6.0f;
                             IsBattleGroundTrap = true;
                         }
                     }


### PR DESCRIPTION
# Fix: BG buff pads (Berserking/Speed/Restoration) never trigger for anyone

## Symptom

WSG's Berserking and Speed buff pads never grant their buff, for bots or real
players. Directly reproduced: stood on top of the Berserking pad repeatedly
with a real character, nothing happened. Watched bots fight and die on top of
the pad without ever picking it up.

## Root cause

`GameObject::Update()`'s `GAMEOBJECT_TYPE_TRAP` handling has a documented hack:
when a trap's own `radius` field (`data2`) is `0`, it substitutes the
`cooldown` field (`data5`) as the activation radius instead:

```cpp
float radius = float(goInfo->trap.radius);
if (!radius)
{
    if (goInfo->trap.cooldown != 3)
        return;
    else
    {
        if (m_respawnTime > 0)
            break;

        // battlegrounds gameobjects has data2 == 0 && data5 == 3
        radius = float(goInfo->trap.cooldown);
        IsBattleGroundTrap = true;
    }
}
```

WSG's buff pad templates (`gameobject_template` entries for "Berserk Buff",
"Speed Buff", "Restoration Buff") all have `cooldown=3` - chosen as a sensible
3-*second* reuse timer between casts. The hack above also turns that same `3`
into a 3-*yard* trigger radius, which is far too tight for a pad players/bots
walk near rather than stand on an exact mark. This pattern (`data2==0 &&
data5==3`) is generic to the trap-update code, so it likely affects the
equivalent buff pads in AB/AV/EY too, not just WSG - I only had WSG bots to
observe directly.

Separately, `gameobject_template` has zero spawns anywhere for the
"Restoration Buff" GO variants (184965/184971/184974/184977) - the healing
buff pad isn't seeded into the world at all. That's a DB-content gap, not a
code bug, and is a separate issue from this radius fix.

## How it was confirmed

Added temporary, heavily throttled logging (5s per-object, ~4 objects total -
well under anything that would stress the tick loop) directly in the trap's
proximity search, filtered to just the WSG buff pad GO template IDs. On a real
live WSG match:

- **923 proximity samples over ~20 minutes, zero successful triggers.**
- The closest anyone (bots and a real player) ever got was **3.24 yards**,
  missing the 3.0-yard radius by 0.24 yards.
- Z-alignment was never the problem - `dz` (height difference) was
  consistently under a yard in the near-misses, ruling out a terrain/model
  offset theory.

Sample of near-misses before the fix:

```
GO 90006 (Berserk Buff) - nearest player Relli at 2d=3.14 3d=3.24 dz=0.86
GO 90007 (Berserk Buff) - nearest player Mesohpihoo at 2d=5.23 3d=5.23 dz=0.15
GO 90006 (Berserk Buff) - nearest player Celinari at 2d=6.36 3d=6.37 dz=0.46
```

## Fix

Use a dedicated 6.0-yard radius for this hack path instead of reusing
`trap.cooldown`. `trap.cooldown` continues to govern the actual reuse timer
via the unrelated `m_cooldownTime` assignment further down in the same
function - untouched by this change.

## Verification

Deployed live and watched the same logging channel after the fix: **3
successful triggers within minutes** of the new radius going live (two random
bots, one GM-piloted test character), against zero in the ~20 minutes prior on
the broken radius.
