### PR TITLE
core: expose generic synchronous character materialization

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -103,6 +103,8 @@ set (game_SRCS
     Handlers/BattleGroundHandler.cpp
     Handlers/ChannelBroadcaster.cpp
     Handlers/ChannelHandler.cpp
+    Handlers/CharacterCreation.cpp
+    Handlers/CharacterCreation.h
     Handlers/CharacterHandler.cpp
     Handlers/ChatHandler.cpp
     Handlers/CombatHandler.cpp

--- a/src/game/Handlers/CharacterCreation.cpp
+++ b/src/game/Handlers/CharacterCreation.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2005-2011 MaNGOS <http://getmangos.com/>
+ * Generic synchronous world-thread character materialization.
+ * Reuses the real packet creation validation/persistence path.
+ */
+
+#include "Handlers/CharacterCreation.h"
+
+#include "Common.h"
+#include "Database/DatabaseEnv.h"
+#include "SharedDefines.h"
+#include "World.h"
+#include "WorldSession.h"
+#include "ObjectMgr.h"
+#include "AccountMgr.h"
+#include "Player.h"
+#include "MapNodes/MasterPlayer.h"
+#include "Database/DBCStores.h"
+#include "Database/DBCStructure.h"
+#include "Log.h"
+#include "Util.h"
+#include "ObjectAccessor.h"
+#include "ScriptObjects.h"
+#include "Logging/DatabaseLogger.hpp"
+#include "Config.hpp"
+
+extern uint32 realmID;
+
+enum CinematicsSkipMode
+{
+    CINEMATICS_SKIP_NONE      = 0,
+    CINEMATICS_SKIP_SAME_RACE = 1,
+    CINEMATICS_SKIP_ALL       = 2,
+};
+
+namespace CharacterCreation
+{
+
+CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo const& info)
+{
+    CharacterCreateOutcome outcome;
+    outcome.result = CHAR_CREATE_ERROR;
+    outcome.guid.Clear();
+
+    // Must be called from world thread. There is no explicit IsWorldThread()
+    // helper, but all callers are world-thread packet or module logic; we
+    // keep the function synchronous and document the requirement.
+
+    if (!accountId)
+        return outcome;
+
+    std::string accName;
+    if (!sAccountMgr.GetName(accountId, accName))
+        return outcome;
+
+    AccountTypes sec = sAccountMgr.GetSecurity(accountId);
+
+    // Account limits - use DB count (synchronous, bounded, not per-tick).
+    uint32 charCount = sAccountMgr.GetCharactersCount(accountId);
+    if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM))
+    {
+        outcome.result = CHAR_CREATE_SERVER_LIMIT;
+        return outcome;
+    }
+    if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_ACCOUNT))
+    {
+        outcome.result = CHAR_CREATE_ACCOUNT_LIMIT;
+        return outcome;
+    }
+
+    Team team = Player::TeamForRace(info.race);
+    if (sec == SEC_PLAYER)
+    {
+        bool disabled = false;
+        if (uint32 mask = sWorld.getConfig(CONFIG_UINT32_CHARACTERS_CREATING_DISABLED))
+        {
+            switch (team)
+            {
+                case ALLIANCE: disabled = mask & (1 << 0); break;
+                case HORDE:    disabled = mask & (1 << 1); break;
+                default: break;
+            }
+        }
+        if (!disabled)
+            disabled = sObjectMgr.IsFactionImbalanced(team);
+        if (disabled)
+        {
+            outcome.result = CHAR_CREATE_DISABLED;
+            return outcome;
+        }
+    }
+
+    ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(info.class_);
+    ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(info.race);
+    if (!classEntry || !raceEntry)
+    {
+        outcome.result = CHAR_CREATE_FAILED;
+        return outcome;
+    }
+    if (raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
+    {
+        outcome.result = CHAR_CREATE_DISABLED;
+        return outcome;
+    }
+
+    PlayerInfo const* playerInfo = sObjectMgr.GetPlayerInfo(info.race, info.class_);
+    if (!playerInfo)
+    {
+        outcome.result = CHAR_CREATE_ERROR;
+        return outcome;
+    }
+
+    std::string name = info.name;
+    if (!normalizePlayerName(name))
+    {
+        outcome.result = CHAR_NAME_NO_NAME;
+        return outcome;
+    }
+
+    uint8 nameRes = ObjectMgr::CheckPlayerName(name, true);
+    if (nameRes != CHAR_NAME_SUCCESS)
+    {
+        outcome.result = nameRes;
+        return outcome;
+    }
+
+    if (sec == SEC_PLAYER && sObjectMgr.IsReservedName(name))
+    {
+        outcome.result = CHAR_NAME_RESERVED;
+        return outcome;
+    }
+
+    if (ObjectGuid existingGuid = sObjectMgr.GetPlayerGuidByName(name))
+    {
+        PlayerCacheData const* pExistingData = sObjectMgr.GetPlayerDataByGUID(existingGuid.GetCounter());
+        if (pExistingData && pExistingData->sName == name)
+        {
+            outcome.result = CHAR_CREATE_NAME_IN_USE;
+            return outcome;
+        }
+        else
+        {
+            sObjectMgr.DeletePlayerNameFromCache(name);
+            sLog.outError("Character name %s taken but no player data in cache!", name.c_str());
+        }
+    }
+
+    bool allowTwoSide = !sWorld.IsPvPRealm() || sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_ACCOUNTS) || sec > SEC_PLAYER;
+    CinematicsSkipMode skipCinematics = CinematicsSkipMode(sWorld.getConfig(CONFIG_UINT32_SKIP_CINEMATICS));
+    bool haveSameRace = false;
+    if (!allowTwoSide || skipCinematics == CINEMATICS_SKIP_SAME_RACE)
+    {
+        std::vector<PlayerCacheData*> characters;
+        sObjectMgr.GetPlayerDataForAccount(accountId, characters);
+        if (!characters.empty())
+        {
+            PlayerCacheData* cData = characters.front();
+            uint8 accRace = cData->uiRace;
+            if (!allowTwoSide)
+            {
+                if (accRace == 0 || Player::TeamForRace(accRace) != team)
+                {
+                    outcome.result = CHAR_CREATE_PVP_TEAMS_VIOLATION;
+                    return outcome;
+                }
+            }
+            auto it = characters.begin();
+            while (it != characters.end() && skipCinematics == CINEMATICS_SKIP_SAME_RACE && !haveSameRace)
+            {
+                accRace = (*it)->uiRace;
+                haveSameRace = info.race == accRace;
+                ++it;
+            }
+        }
+    }
+
+    if (info.gender != uint8(GENDER_MALE) && info.gender != uint8(GENDER_FEMALE))
+    {
+        outcome.result = CHAR_CREATE_ERROR;
+        return outcome;
+    }
+
+    // Transient session for Player::Create/SaveToDB. Not registered in World,
+    // not a fake network session, purely a helper to satisfy Player's
+    // session dependency (security, account id) on the world thread.
+    WorldSession dummySession(accountId, nullptr, sec, 0, LOCALE_enUS, "127.0.0.1", 0);
+
+    std::unique_ptr<Player> pNewChar = std::make_unique<Player>(&dummySession);
+    if (!pNewChar->Create(sObjectMgr.GeneratePlayerLowGuid(), name, info.race, info.class_, info.gender, info.skin, info.face, info.hairStyle, info.hairColor, info.facialHair))
+    {
+        outcome.result = CHAR_CREATE_ERROR;
+        return outcome;
+    }
+
+    MasterPlayer masterPlayer(&dummySession);
+    masterPlayer.Create(pNewChar.get());
+
+    if ((haveSameRace && skipCinematics == CINEMATICS_SKIP_SAME_RACE) || skipCinematics == CINEMATICS_SKIP_ALL)
+        pNewChar->SetCinematic(1);
+
+    pNewChar->SetAtLoginFlag(AT_LOGIN_FIRST);
+
+    if (info.challengeMask)
+        pNewChar->SetPlayerVariable(PlayerVariables::PendingChallengeMask, std::to_string(info.challengeMask));
+
+    if (!pNewChar->SaveToDB(false, true, false))
+    {
+        outcome.result = CHAR_CREATE_ERROR;
+        return outcome;
+    }
+    masterPlayer.SaveToDB();
+
+    sObjectMgr.InsertPlayerInCache(pNewChar.get());
+    sObjectMgr.UpdatePlayerCachedPosition(pNewChar.get());
+
+    uint32 newCount = sAccountMgr.GetCharactersCount(accountId);
+    if (newCount == 0) // fallback if query races or fails
+        newCount = charCount + 1;
+    LoginDatabase.PExecute("REPLACE INTO realmcharacters (numchars, acctid, realmid) VALUES (%u, %u, %u)", newCount, accountId, realmID);
+
+    outcome.guid = pNewChar->GetObjectGuid();
+    outcome.result = CHAR_CREATE_SUCCESS;
+
+    // Mirror packet-path side effects without coupling to a live session.
+    sLog.out(LOG_CHAR, "[%s:%u@%s] Create Character:[%s] (guid: %u) via synchronous materialization",
+             accName.c_str(), accountId, "127.0.0.1", name.c_str(), pNewChar->GetGUIDLow());
+    sDBLogger.LogCharAction({ pNewChar->GetGUIDLow(), accountId, LogCharAction::ActionCreate, {} });
+    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CREATE, [&](PlayerScript* script)
+    {
+        script->OnCreate(pNewChar.get());
+    });
+    sObjectMgr.IncreaseActivePlayersCount(team);
+
+    return outcome;
+}
+
+} // namespace CharacterCreation

--- a/src/game/Handlers/CharacterCreation.cpp
+++ b/src/game/Handlers/CharacterCreation.cpp
@@ -41,6 +41,7 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
     CharacterCreateOutcome outcome;
     outcome.result = CHAR_CREATE_ERROR;
     outcome.guid.Clear();
+    outcome.newCharactersCount = 0;
 
     // Must be called from world thread. There is no explicit IsWorldThread()
     // helper, but all callers are world-thread packet or module logic; we
@@ -55,18 +56,12 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
 
     AccountTypes sec = sAccountMgr.GetSecurity(accountId);
 
-    // Account limits - use DB count (synchronous, bounded, not per-tick).
+    // Effective IP for logging/session; keep module calls generic with safe default.
+    std::string effectiveIP = info.remoteAddress.empty() ? std::string("127.0.0.1") : info.remoteAddress;
+
+    // Carry pre-create count for limit checks and later realmcharacters ownership.
+    // Captured early but limit checks are after name/race/class to preserve original ordering.
     uint32 charCount = sAccountMgr.GetCharactersCount(accountId);
-    if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM))
-    {
-        outcome.result = CHAR_CREATE_SERVER_LIMIT;
-        return outcome;
-    }
-    if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_ACCOUNT))
-    {
-        outcome.result = CHAR_CREATE_ACCOUNT_LIMIT;
-        return outcome;
-    }
 
     Team team = Player::TeamForRace(info.race);
     if (sec == SEC_PLAYER)
@@ -145,6 +140,19 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
         }
     }
 
+    // Restore original ordering: account limits after name/race/class checks
+    // so invalid name/race/class and anticheat are not hidden by limit errors.
+    if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM))
+    {
+        outcome.result = CHAR_CREATE_SERVER_LIMIT;
+        return outcome;
+    }
+    if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_ACCOUNT))
+    {
+        outcome.result = CHAR_CREATE_ACCOUNT_LIMIT;
+        return outcome;
+    }
+
     bool allowTwoSide = !sWorld.IsPvPRealm() || sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_ACCOUNTS) || sec > SEC_PLAYER;
     CinematicsSkipMode skipCinematics = CinematicsSkipMode(sWorld.getConfig(CONFIG_UINT32_SKIP_CINEMATICS));
     bool haveSameRace = false;
@@ -183,7 +191,9 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
     // Transient session for Player::Create/SaveToDB. Not registered in World,
     // not a fake network session, purely a helper to satisfy Player's
     // session dependency (security, account id) on the world thread.
-    WorldSession dummySession(accountId, nullptr, sec, 0, LOCALE_enUS, "127.0.0.1", 0);
+    // OnCreate limitation: Player is not in world and session is transient;
+    // hooks must not assume FindSession/online/world presence (see header).
+    WorldSession dummySession(accountId, nullptr, sec, 0, LOCALE_enUS, effectiveIP, 0);
 
     std::unique_ptr<Player> pNewChar = std::make_unique<Player>(&dummySession);
     if (!pNewChar->Create(sObjectMgr.GeneratePlayerLowGuid(), name, info.race, info.class_, info.gender, info.skin, info.face, info.hairStyle, info.hairColor, info.facialHair))
@@ -213,17 +223,18 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
     sObjectMgr.InsertPlayerInCache(pNewChar.get());
     sObjectMgr.UpdatePlayerCachedPosition(pNewChar.get());
 
-    uint32 newCount = sAccountMgr.GetCharactersCount(accountId);
-    if (newCount == 0) // fallback if query races or fails
-        newCount = charCount + 1;
+    // Avoid post-commit async recount lag: carry pre-create count + 1 deterministically
+    // within generic API ownership instead of re-querying CharacterDatabase.
+    uint32 newCount = charCount + 1;
     LoginDatabase.PExecute("REPLACE INTO realmcharacters (numchars, acctid, realmid) VALUES (%u, %u, %u)", newCount, accountId, realmID);
 
     outcome.guid = pNewChar->GetObjectGuid();
     outcome.result = CHAR_CREATE_SUCCESS;
+    outcome.newCharactersCount = newCount;
 
-    // Mirror packet-path side effects without coupling to a live session.
+    // Preserve original packet-path creator IP in LOG_CHAR; module default is generic dummy.
     sLog.out(LOG_CHAR, "[%s:%u@%s] Create Character:[%s] (guid: %u) via synchronous materialization",
-             accName.c_str(), accountId, "127.0.0.1", name.c_str(), pNewChar->GetGUIDLow());
+             accName.c_str(), accountId, effectiveIP.c_str(), name.c_str(), pNewChar->GetGUIDLow());
     sDBLogger.LogCharAction({ pNewChar->GetGUIDLow(), accountId, LogCharAction::ActionCreate, {} });
     ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CREATE, [&](PlayerScript* script)
     {

--- a/src/game/Handlers/CharacterCreation.cpp
+++ b/src/game/Handlers/CharacterCreation.cpp
@@ -59,9 +59,21 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
     // Effective IP for logging/session; keep module calls generic with safe default.
     std::string effectiveIP = info.remoteAddress.empty() ? std::string("127.0.0.1") : info.remoteAddress;
 
-    // Carry pre-create count for limit checks and later realmcharacters ownership.
-    // Captured early but limit checks are after name/race/class to preserve original ordering.
-    uint32 charCount = sAccountMgr.GetCharactersCount(accountId);
+    // Character count with failure distinction: COUNT(*) returns a row with 0 when empty,
+    // so null QueryResult means DB error, not zero characters. Fail closed on error
+    // to avoid silently weakening per-realm/per-account limits.
+    uint32 charCount = 0;
+    bool charCountFailed = false;
+    if (QueryResult* cntRes = CharacterDatabase.PQuery("SELECT COUNT(guid) FROM characters WHERE account = '%u'", accountId))
+    {
+        charCount = (*cntRes)[0].GetUInt32();
+        delete cntRes;
+    }
+    else
+    {
+        sLog.outError("CharacterCreation::CreateCharacter: character count query failed for account %u", accountId);
+        charCountFailed = true;
+    }
 
     Team team = Player::TeamForRace(info.race);
     if (sec == SEC_PLAYER)
@@ -95,13 +107,6 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
     if (raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
     {
         outcome.result = CHAR_CREATE_DISABLED;
-        return outcome;
-    }
-
-    PlayerInfo const* playerInfo = sObjectMgr.GetPlayerInfo(info.race, info.class_);
-    if (!playerInfo)
-    {
-        outcome.result = CHAR_CREATE_ERROR;
         return outcome;
     }
 
@@ -142,6 +147,12 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
 
     // Restore original ordering: account limits after name/race/class checks
     // so invalid name/race/class and anticheat are not hidden by limit errors.
+    // Distinguish DB failure from zero: fail closed on count query error.
+    if (charCountFailed)
+    {
+        outcome.result = CHAR_CREATE_ERROR;
+        return outcome;
+    }
     if (charCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM))
     {
         outcome.result = CHAR_CREATE_SERVER_LIMIT;
@@ -180,6 +191,15 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
                 ++it;
             }
         }
+    }
+
+    // Align with original handler/Player::Create order: GetPlayerInfo and gender
+    // after name checks so malformed invalid-name retains CHAR_NAME_NO_NAME
+    // and PassiveAnticheat, not CHAR_CREATE_ERROR.
+    if (!sObjectMgr.GetPlayerInfo(info.race, info.class_))
+    {
+        outcome.result = CHAR_CREATE_ERROR;
+        return outcome;
     }
 
     if (info.gender != uint8(GENDER_MALE) && info.gender != uint8(GENDER_FEMALE))
@@ -232,7 +252,8 @@ CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo con
     outcome.result = CHAR_CREATE_SUCCESS;
     outcome.newCharactersCount = newCount;
 
-    // Preserve original packet-path creator IP in LOG_CHAR; module default is generic dummy.
+    // Preserve original packet-path operational logging with effective IP (generic dummy for modules).
+    BASIC_LOG("Account: %d (IP: %s) Create Character:[%s] (guid: %u)", accountId, effectiveIP.c_str(), name.c_str(), pNewChar->GetGUIDLow());
     sLog.out(LOG_CHAR, "[%s:%u@%s] Create Character:[%s] (guid: %u) via synchronous materialization",
              accName.c_str(), accountId, effectiveIP.c_str(), name.c_str(), pNewChar->GetGUIDLow());
     sDBLogger.LogCharAction({ pNewChar->GetGUIDLow(), accountId, LogCharAction::ActionCreate, {} });

--- a/src/game/Handlers/CharacterCreation.h
+++ b/src/game/Handlers/CharacterCreation.h
@@ -50,6 +50,9 @@ namespace CharacterCreation
     // Synchronous, world-thread only. Reuses Player::Create / SaveToDB and the
     // exact validation path of HandleCharCreateOpcode. Must not be called from
     // a DB worker and must not use a fake registered WorldSession.
+    // Per-realm/per-account limit checks distinguish DB count failure (null
+    // QueryResult) from zero (row with 0) and fail closed with
+    // CHAR_CREATE_ERROR rather than silently weakening limits.
     // Transient-session OnCreate limitation: Player passed to
     // PlayerScript::OnCreate is not yet in world and the session is a
     // transient helper not registered in World nor tied to a network socket;

--- a/src/game/Handlers/CharacterCreation.h
+++ b/src/game/Handlers/CharacterCreation.h
@@ -1,0 +1,51 @@
+#pragma once
+/*
+ * Copyright (C) 2005-2011 MaNGOS <http://getmangos.com/>
+ * Copyright (C) 2009-2011 MaNGOSZero <https://github.com/mangos/zero>
+ * Generic synchronous world-thread character materialization.
+ * No RNDBOT / bot concepts, no raw INSERT, no DB-worker use.
+ */
+
+#include "Common.h"
+#include "ObjectGuid.h"
+#include "SharedDefines.h"
+#include <string>
+
+// Input bundle for synchronous character creation. Mirrors the data parsed from
+// CMSG_CHAR_CREATE (except packet framing). All validation is reused from the
+// real packet path.
+struct CharacterCreateInfo
+{
+    std::string name;
+    uint8 race = 0;
+    uint8 class_ = 0;
+    uint8 gender = 0;
+    uint8 skin = 0;
+    uint8 face = 0;
+    uint8 hairStyle = 0;
+    uint8 hairColor = 0;
+    uint8 facialHair = 0;
+    uint8 outfitId = 0;
+    uint32 challengeMask = 0;
+};
+
+// Outcome of CreateCharacter. `result` uses the same values as SharedDefines
+// ResponseCodes (CHAR_CREATE_*/CHAR_NAME_*). `guid` is valid only on
+// CHAR_CREATE_SUCCESS.
+struct CharacterCreateOutcome
+{
+    uint8 result = 0;
+    ObjectGuid guid;
+};
+
+namespace CharacterCreation
+{
+    // Synchronous, world-thread only. Reuses Player::Create / SaveToDB and the
+    // exact validation path of HandleCharCreateOpcode. Must not be called from
+    // a DB worker and must not use a fake registered WorldSession.
+    CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo const& info);
+}
+
+// Compile-time contract: outcome result values must be the packet values.
+static_assert(uint8(CHAR_CREATE_SUCCESS) != uint8(CHAR_CREATE_ERROR), "ResponseCodes distinct");
+static_assert(uint8(CHAR_NAME_SUCCESS) != uint8(CHAR_NAME_NO_NAME), "name codes distinct");

--- a/src/game/Handlers/CharacterCreation.h
+++ b/src/game/Handlers/CharacterCreation.h
@@ -14,6 +14,9 @@
 // Input bundle for synchronous character creation. Mirrors the data parsed from
 // CMSG_CHAR_CREATE (except packet framing). All validation is reused from the
 // real packet path.
+// remoteAddress is optional: packet path should pass GetRemoteAddress(),
+// module default is generic safe dummy (keeps module calls generic while
+// preserving original packet IP in LOG_CHAR).
 struct CharacterCreateInfo
 {
     std::string name;
@@ -27,15 +30,19 @@ struct CharacterCreateInfo
     uint8 facialHair = 0;
     uint8 outfitId = 0;
     uint32 challengeMask = 0;
+    std::string remoteAddress = "127.0.0.1";
 };
 
 // Outcome of CreateCharacter. `result` uses the same values as SharedDefines
 // ResponseCodes (CHAR_CREATE_*/CHAR_NAME_*). `guid` is valid only on
-// CHAR_CREATE_SUCCESS.
+// CHAR_CREATE_SUCCESS. newCharactersCount is the expected realmcharacters
+// count (pre-create DB count + 1) on success, carried to avoid post-commit
+// async recount lag; callers may sync cached _charactersCount from it.
 struct CharacterCreateOutcome
 {
     uint8 result = 0;
     ObjectGuid guid;
+    uint32 newCharactersCount = 0;
 };
 
 namespace CharacterCreation
@@ -43,6 +50,11 @@ namespace CharacterCreation
     // Synchronous, world-thread only. Reuses Player::Create / SaveToDB and the
     // exact validation path of HandleCharCreateOpcode. Must not be called from
     // a DB worker and must not use a fake registered WorldSession.
+    // Transient-session OnCreate limitation: Player passed to
+    // PlayerScript::OnCreate is not yet in world and the session is a
+    // transient helper not registered in World nor tied to a network socket;
+    // hooks must not assume FindSession/online/world presence and must handle
+    // that the Player is valid only during the synchronous call.
     CharacterCreateOutcome CreateCharacter(uint32 accountId, CharacterCreateInfo const& info);
 }
 

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -29,6 +29,7 @@
 #include "World.h"
 #include "ObjectMgr.h"
 #include "Player.h"
+#include "Handlers/CharacterCreation.h"
 #include "Guild.h"
 #include "GuildMgr.h"
 #include "UpdateMask.h"
@@ -221,210 +222,58 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket & recv_data)
 {
     std::string name;
     uint8 race_, class_;
-
     recv_data >> name;
-
     recv_data >> race_;
     recv_data >> class_;
-
-    // extract other data required for player creating
     uint8 gender, skin, face, hairStyle, hairColor, facialHair, outfitId;
     recv_data >> gender >> skin >> face;
     recv_data >> hairStyle >> hairColor >> facialHair >> outfitId;
-
     uint32 challengeMask;
     recv_data >> challengeMask;
 
-    WorldPacket data(SMSG_CHAR_CREATE, 1);                  // returned with diff.values in all cases
+    CharacterCreateInfo info;
+    info.name = name;
+    info.race = race_;
+    info.class_ = class_;
+    info.gender = gender;
+    info.skin = skin;
+    info.face = face;
+    info.hairStyle = hairStyle;
+    info.hairColor = hairColor;
+    info.facialHair = facialHair;
+    info.outfitId = outfitId;
+    info.challengeMask = challengeMask;
 
-    Team team = Player::TeamForRace(race_);
-    if (GetSecurity() == SEC_PLAYER)
+    CharacterCreateOutcome outcome = CharacterCreation::CreateCharacter(GetAccountId(), info);
+
+    if (outcome.result == CHAR_CREATE_SUCCESS)
+        _charactersCount = std::min<uint32>(_charactersCount + 1, sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM));
+
+    if (outcome.result == CHAR_CREATE_FAILED)
     {
-        bool disabled = false;
-
-        if (uint32 mask = sWorld.getConfig(CONFIG_UINT32_CHARACTERS_CREATING_DISABLED))
+        ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(class_);
+        ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(race_);
+        if (!classEntry || !raceEntry)
         {
-            switch (team)
-            {
-            case ALLIANCE:
-                disabled = mask & (1 << 0);
-                break;
-            case HORDE:
-                disabled = mask & (1 << 1);
-                break;
-            }
+            std::stringstream oss;
+            oss << "Attempt to create character of invalid Class (" << int(class_) << ") or Race (" << int(race_) << ")";
+            ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_INFO_LOG);
         }
-
-        if (!disabled)
-            disabled = sObjectMgr.IsFactionImbalanced(team);
-
-        if (disabled)
+        else if (raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
         {
-            data << (uint8)CHAR_CREATE_DISABLED;
-            SendPacket(&data);
-            return;
+            std::stringstream oss;
+            oss << "Attempt to create character of non-playable Race (" << int(race_) << ")";
+            ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_INFO_LOG);
         }
     }
-
-    ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(class_);
-    ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(race_);
-
-    if (!classEntry || !raceEntry)
+    else if (outcome.result == CHAR_NAME_NO_NAME)
     {
-        data << (uint8)CHAR_CREATE_FAILED;
-        SendPacket(&data);
-        std::stringstream oss;
-        oss << "Attempt to create character of invalid Class (" << int(class_) << ") or Race (" << int(race_) << ")";
-        ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_INFO_LOG);
-        return;
-    }
-
-    if (raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
-    {
-        data << (uint8)CHAR_CREATE_DISABLED;
-        SendPacket(&data);
-        std::stringstream oss;
-        oss << "Attempt to create character of non-playable Race (" << int(race_) << ")";
-        ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_INFO_LOG);
-        return;
-    }
-
-    // Prevent character creating with invalid name
-    if (!normalizePlayerName(name))
-    {
-        data << (uint8)CHAR_NAME_NO_NAME;
-        SendPacket(&data);
         ProcessAnticheatAction("PassiveAnticheat", "Attempt to create character with invalid name", CHEAT_ACTION_INFO_LOG);
-        return;
     }
 
-    // check name limitations
-    uint8 res = ObjectMgr::CheckPlayerName(name, true);
-    if (res != CHAR_NAME_SUCCESS)
-    {
-        data << uint8(res);
-        SendPacket(&data);
-        return;
-    }
-
-    if (GetSecurity() == SEC_PLAYER && sObjectMgr.IsReservedName(name))
-    {
-        data << (uint8)CHAR_NAME_RESERVED;
-        SendPacket(&data);
-        return;
-    }
-
-    if (ObjectGuid existingGuid = sObjectMgr.GetPlayerGuidByName(name))
-    {
-        PlayerCacheData const* pExistingData = sObjectMgr.GetPlayerDataByGUID(existingGuid.GetCounter());
-        if (pExistingData && pExistingData->sName == name)
-        {
-            data << (uint8)CHAR_CREATE_NAME_IN_USE;
-            SendPacket(&data);
-            return;
-        }
-        else
-        {
-            sObjectMgr.DeletePlayerNameFromCache(name);
-            sLog.outError("Character name %s taken but no player data in cache!", name.c_str());
-        }
-    }
-
-    if (_charactersCount >= sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM))
-    {
-        data << (uint8)CHAR_CREATE_SERVER_LIMIT;
-        SendPacket(&data);
-        return;
-    }
-
-    bool AllowTwoSideAccounts = !sWorld.IsPvPRealm() || sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_ACCOUNTS) || GetSecurity() > SEC_PLAYER;
-    CinematicsSkipMode skipCinematics = CinematicsSkipMode(sWorld.getConfig(CONFIG_UINT32_SKIP_CINEMATICS));
-
-    bool have_same_race = false;
-    if (!AllowTwoSideAccounts || skipCinematics == CINEMATICS_SKIP_SAME_RACE)
-    {
-        std::vector<PlayerCacheData*> characters;
-        sObjectMgr.GetPlayerDataForAccount(GetAccountId(), characters);
-
-        if (!characters.empty())
-        {
-            PlayerCacheData* cData = characters.front();
-
-            uint8 acc_race = cData->uiRace;
-
-            // need to check team only for first character
-            // TODO: what to if account already has characters of both races?
-            if (!AllowTwoSideAccounts)
-            {
-                if (acc_race == 0 || Player::TeamForRace(acc_race) != team)
-                {
-                    data << (uint8)CHAR_CREATE_PVP_TEAMS_VIOLATION;
-                    SendPacket(&data);
-                    return;
-                }
-            }
-
-            // search same race for cinematic or same class if need
-            // TODO: check if cinematic already shown? (already logged in?; cinematic field)
-            std::vector<PlayerCacheData*>::iterator iter = characters.begin();
-            while (iter != characters.end() && skipCinematics == CINEMATICS_SKIP_SAME_RACE && !have_same_race)
-            {
-                acc_race = (*iter)->uiRace;
-
-                have_same_race = race_ == acc_race;
-                ++iter;
-            }
-        }
-    }
-
-    // created only to call SaveToDB()
-    std::unique_ptr<Player> pNewChar = std::make_unique<Player>(this);
-    if (!pNewChar->Create(sObjectMgr.GeneratePlayerLowGuid(), name, race_, class_, gender, skin, face, hairStyle, hairColor, facialHair))
-    {
-        // Player not create (race/class problem?)
-        data << (uint8)CHAR_CREATE_ERROR;
-        SendPacket(&data);
-        return;
-    }
-
-    MasterPlayer masterPlayer(this);
-    masterPlayer.Create(pNewChar.get());
-    if ((have_same_race && skipCinematics == CINEMATICS_SKIP_SAME_RACE) || skipCinematics == CINEMATICS_SKIP_ALL)
-        pNewChar->SetCinematic(1);                          // not show intro
-
-    pNewChar->SetAtLoginFlag(AT_LOGIN_FIRST);               // First login
-
-    // Challenge spells are given on first login and not on character creation
-    if (challengeMask)
-        pNewChar->SetPlayerVariable(PlayerVariables::PendingChallengeMask, std::to_string(challengeMask));
-
-    // Player created, save it now
-    if (!pNewChar->SaveToDB(false, true, false))
-    {
-        data << (uint8)CHAR_CREATE_ERROR;
-        SendPacket(&data);
-        return;
-    }
-    masterPlayer.SaveToDB();
-
-    sObjectMgr.InsertPlayerInCache(pNewChar.get());
-    sObjectMgr.UpdatePlayerCachedPosition(pNewChar.get());
-    _charactersCount += 1;
-
-    LoginDatabase.PExecute("REPLACE INTO realmcharacters (numchars, acctid, realmid) VALUES (%u, %u, %u)",  _charactersCount, GetAccountId(), realmID);
-
-    data << (uint8)CHAR_CREATE_SUCCESS;
+    WorldPacket data(SMSG_CHAR_CREATE, 1);
+    data << uint8(outcome.result);
     SendPacket(&data);
-
-    std::string IP_str = GetRemoteAddress();
-    BASIC_LOG("Account: %d (IP: %s) Create Character:[%s] (guid: %u)", GetAccountId(), IP_str.c_str(), name.c_str(), pNewChar->GetGUIDLow());
-    sLog.out(LOG_CHAR, "[%s:%u@%s] Create Character:[%s] (guid: %u)", GetUsername().c_str(), GetAccountId(), IP_str.c_str(), name.c_str(), pNewChar->GetGUIDLow());
-    sDBLogger.LogCharAction({ pNewChar->GetGUIDLow(), GetAccountId(), LogCharAction::ActionCreate, {} });
-    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CREATE, [&](PlayerScript* script)
-    {
-        script->OnCreate(pNewChar.get());
-    });
-    sObjectMgr.IncreaseActivePlayersCount(team);
 }
 
 void WorldSession::HandleCharDeleteOpcode(WorldPacket & recv_data)

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -266,7 +266,12 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket & recv_data)
             oss << "Attempt to create character of invalid Class (" << int(class_) << ") or Race (" << int(race_) << ")";
             ProcessAnticheatAction("PassiveAnticheat", oss.str().c_str(), CHEAT_ACTION_INFO_LOG);
         }
-        else if (raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
+    }
+    else if (outcome.result == CHAR_CREATE_DISABLED)
+    {
+        ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(class_);
+        ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(race_);
+        if (classEntry && raceEntry && raceEntry->HasFlag(CHRRACES_FLAGS_NOT_PLAYABLE))
         {
             std::stringstream oss;
             oss << "Attempt to create character of non-playable Race (" << int(race_) << ")";

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -243,11 +243,18 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket & recv_data)
     info.facialHair = facialHair;
     info.outfitId = outfitId;
     info.challengeMask = challengeMask;
+    info.remoteAddress = GetRemoteAddress();
 
     CharacterCreateOutcome outcome = CharacterCreation::CreateCharacter(GetAccountId(), info);
 
     if (outcome.result == CHAR_CREATE_SUCCESS)
-        _charactersCount = std::min<uint32>(_charactersCount + 1, sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM));
+    {
+        uint32 limit = sWorld.getConfig(CONFIG_UINT32_CHARACTERS_PER_REALM);
+        if (outcome.newCharactersCount)
+            _charactersCount = std::min(outcome.newCharactersCount, limit);
+        else
+            _charactersCount = std::min<uint32>(_charactersCount + 1, limit);
+    }
 
     if (outcome.result == CHAR_CREATE_FAILED)
     {


### PR DESCRIPTION
## Summary
- expose a generic world-thread `CharacterCreation::CreateCharacter` API by extracting the native character-create validation/persistence path
- keep `HandleCharCreateOpcode` on the same validation, packet, anticheat, cache, realm-count, and hook behavior
- support module callers without registering a fake session or touching Player/SaveToDB from a DB worker

## Scope and safety
- No RNDBOT, PlayerBots, or module-specific concepts.
- Synchronous and world-thread-only; callers must throttle rare materialization requests.
- Uses real `Player::Create`/`SaveToDB`, playercreateinfo/DBC validation, account/name limits, transactions, cache updates, realmcharacters, and `OnCreate`.
- Transient session is unregistered/socketless and valid only for the synchronous call; module callers receive a generic outcome and GUID.
- PR #411 is untouched and remains a separate frozen Headless/session prerequisite.

## Validation
- Docker/incremental `game` target built through `libgame.a` at review/final tip.
- Fresh syntax checks for both changed translation units.
- `git diff --check` and no bot-coupling/raw character INSERT checks.
- No live DB/runtime character creation test was available.