### PR TITLE
scripts: wire authoritative custom dungeon portals

### DIFF
--- a/sql/database_updates/world/20260826000000_world.sql
+++ b/sql/database_updates/world/20260826000000_world.sql
@@ -1,0 +1,13 @@
+-- Fix custom_dungeon_portal GO type for script dispatch (reviewer blocker: GENERIC never reaches OnGossipHello).
+-- All 13 bound `custom_dungeon_portal` GOs were type 5 GENERIC, which HandleGameObjectUseOpcode discards
+-- before GameObject::Use / sScriptMgr.OnGameObjectUse, so the registered GameObjectScript never ran.
+-- Switch only the 10 authoritative portals with verified areatrigger_teleport destinations to native
+-- clickable GOOBER (type 10), the minimal type that routes via GameObject::Use -> OnGameObjectUse
+-- -> GameObjectScript::OnGossipHello (see SpellHandler.cpp CMSG_GAMEOBJ_USE and GameObject.cpp GOOBER case).
+-- GOOBER with flags 0 and lockId 0 is interactive via PlayerCanUse; the script consumes (returns true)
+-- before the default GOOBER activation path, so no state/anim side-effects.
+-- Unsupported entries (112920 Scarlet Citadel Entr, 112923/112924 Caverns Placeholders) stay type 5;
+-- if ever retargeted to GOOBER, the script now returns true to consume/fail-closed without default activation,
+-- preserving no invented coords / no fake success.
+-- Destinations/phase/level/condition/ghost/combat remain authoritative in areatrigger_teleport and the C++ PortalInfo table.
+UPDATE `gameobject_template` SET `type` = 10 WHERE `entry` IN (112911, 112912, 112915, 112916, 112917, 112918, 112940, 112941, 181580, 181581) AND `script_name` = 'custom_dungeon_portal';

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -410,6 +410,7 @@ world/undercity.cpp
 world/ungoro_crater.cpp
 world/western_plaguelands.cpp
 world/westfall.cpp
+world/custom_dungeon_portal.cpp
 world/wetlands.cpp
 world/winterspring.cpp
 world/stormwind_city.cpp

--- a/src/scripts/ScriptLoader.cpp
+++ b/src/scripts/ScriptLoader.cpp
@@ -35,6 +35,7 @@ void AddSC_dreadsteed_ritual();
 void AddSC_npc_king_gordok();
 
 //world
+void AddSC_custom_dungeon_portal();
 void AddSC_areatrigger_scripts();
 void AddSC_dragons_of_nightmare();
 void AddSC_boss_lord_kazzak();
@@ -413,6 +414,7 @@ void AddScripts()
     AddSC_npc_king_gordok();
 
     //world
+    AddSC_custom_dungeon_portal();
     AddSC_areatrigger_scripts();
     AddSC_dragons_of_nightmare();
     AddSC_boss_lord_kazzak();

--- a/src/scripts/world/custom_dungeon_portal.cpp
+++ b/src/scripts/world/custom_dungeon_portal.cpp
@@ -79,7 +79,7 @@ public:
 
         const PortalInfo* info = GetPortalInfo(go->GetEntry());
         if (!info)
-            return false; // intentionally unsupported — fail closed, no teleport
+            return true; // intentionally unsupported — consume/fail closed, no teleport, no default GO activation
 
         if (player->IsBeingTeleported())
             return true;

--- a/src/scripts/world/custom_dungeon_portal.cpp
+++ b/src/scripts/world/custom_dungeon_portal.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2006-2009 ScriptDev2 <https://scriptdev2.svn.sourceforge.net/>
+ * This program is free software licensed under GPL version 2
+ * See included DOCS/LICENSE.TXT
+ *
+ * Turtle custom dungeon portal handler — authoritative GameObjectScript for
+ * `custom_dungeon_portal`. Destinations and conditions are verbatim from
+ * `areatrigger_teleport` (the same table that drives instance areatriggers)
+ * and from `map_template`/`instance_template`. No coordinates are invented,
+ * no fake success is returned, and no bot-specific coupling is introduced.
+ *
+ * Supported entries are those with a proved areatrigger counterpart.
+ * All other entries sharing the same script_name remain bound to this script
+ * but fail closed (no teleport), so they never produce fake success.
+ */
+
+#include "scriptPCH.h"
+#include "ScriptObjects.h"
+#include "ObjectMgr.h"
+#include "World.h"
+#include "Conditions.h"
+#include "Database/SQLStorages.h"
+#include "Language.h"
+
+struct PortalInfo
+{
+    uint32 entry;
+    WorldLocation dest;
+    uint8 requiredLevel;
+    uint32 requiredCondition;
+    uint8 requiredPhase;
+    char const* message;
+};
+
+static const PortalInfo* GetPortalInfo(uint32 entry)
+{
+    // Destinations/conditions are verbatim from
+    // sql/base/tw_world_areatrigger_teleport.sql (and its database_updates
+    // mirrors). The trigger IDs cited are the authoritative source — this
+    // file does not invent or offset coordinates.
+    static const PortalInfo infos[] =
+    {
+        // Crescent Grove — trigger 5004/5005
+        { 112911, WorldLocation(802,  579.13f,    90.7f,    276.11f,  3.4f),    32, 0, 0, "You must be at least level 32 to enter." },
+        { 112912, WorldLocation(1,    1722.0f, -1272.6f,    163.26f,  5.8f),     0, 0, 0, "" },
+
+        // Black Morass — trigger 1632/1629
+        { 112915, WorldLocation(269, -2002.5f,  6575.3f,   -154.9f,   5.7f),    58, 0, 0, "You must be at least level 58 to enter." },
+        { 112916, WorldLocation(1,   -8756.8f, -4191.3f,   -209.4f,   5.5f),     0, 0, 0, "" },
+
+        // Stormwind Vault — trigger 107/109 (5002/5003 are same entrance)
+        { 112917, WorldLocation(35,    -0.91f,    40.57f,  -24.23f,  1.52f),   58, 0, 0, "You must be at least level 58 to enter." },
+        { 112918, WorldLocation(0,  -8679.12f,  639.337f,  95.819f,  2.29017f),  0, 0, 0, "" },
+
+        // Hateforge Quarry — trigger 5009/5013
+        { 112940, WorldLocation(808, -8173.9f, -3120.6f,   199.8f,   4.7f),    48, 0, 0, "You must be at least level 48 to enter." },
+        { 112941, WorldLocation(0,   -8169.2f, -3106.7f,   200.4f,   1.1f),     0, 0, 0, "" },
+
+        // Karazhan Crypt — trigger 5008/5011
+        { 181580, WorldLocation(800, -11068.1f, -1806.4f,   52.7f,   1.5f),    55, 0, 0, "You must be at least level 55 to enter." },
+        { 181581, WorldLocation(0,   -11068.9f, -1828.6f,   60.26f,  3.1f),     0, 0, 0, "" },
+    };
+
+    for (auto const& info : infos)
+        if (info.entry == entry)
+            return &info;
+    return nullptr;
+}
+
+class custom_dungeon_portal : public GameObjectScript
+{
+public:
+    custom_dungeon_portal() : GameObjectScript("custom_dungeon_portal") {}
+
+    bool OnGossipHello(Player* player, GameObject* go) override
+    {
+        if (!player || !go)
+            return false;
+
+        const PortalInfo* info = GetPortalInfo(go->GetEntry());
+        if (!info)
+            return false; // intentionally unsupported — fail closed, no teleport
+
+        if (player->IsBeingTeleported())
+            return true;
+
+        // Reuse native areatrigger/instance semantics (see
+        // WorldSession::HandleAreaTriggerOpcode in Handlers/MiscHandler.cpp).
+
+        MapEntry const* targetMap = sMapStorage.LookupEntry<MapEntry>(info->dest.mapId);
+        if (!targetMap)
+            return true;
+
+        if (info->requiredPhase > sWorld.GetContentPhase())
+        {
+            if (WorldSession* sess = player->GetSession())
+                sess->SendAreaTriggerMessage(sess->GetMangosString(LANG_INSTANCE_AVAILABLE_IN_PHASE), info->requiredPhase + 1);
+            return true;
+        }
+
+        // Ghost handling mirrors areatrigger: block ghost entry into dungeon.
+        if (!player->IsAlive() && targetMap->IsDungeon())
+        {
+            uint32 corpseMapId = 0;
+            if (Corpse* corpse = player->GetCorpse())
+                corpseMapId = corpse->GetMapId();
+
+            bool canEnterAsGhost = false;
+            uint32 checkMap = corpseMapId;
+            while (checkMap)
+            {
+                if (checkMap == uint32(targetMap->id))
+                {
+                    canEnterAsGhost = true;
+                    break;
+                }
+                if (MapEntry const* me = sMapStorage.LookupEntry<MapEntry>(checkMap))
+                    checkMap = me->IsDungeon() ? me->parent : 0;
+                else
+                    break;
+            }
+
+            if (!canEnterAsGhost)
+            {
+                if (WorldSession* sess = player->GetSession())
+                    sess->SendAreaTriggerMessage("You cannot enter %s while in ghost form.", targetMap->name);
+                return true;
+            }
+
+            // If destination map differs from corpse map, redirect to the
+            // corpse's entrance trigger (same as areatrigger logic when
+            // possible). Keep authoritative destination otherwise.
+            if (info->dest.mapId != corpseMapId)
+            {
+                if (AreaTriggerTeleport const* corpseAt = sObjectMgr.GetMapEntranceTrigger(corpseMapId))
+                {
+                    // Use the corpse entrance only when it points into the
+                    // same dungeon family; otherwise keep original dest.
+                    if (corpseAt->destination.mapId == info->dest.mapId)
+                    {
+                        player->TeleportTo(corpseAt->destination);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (!player->IsGameMaster())
+        {
+            bool levelCheck = player->GetLevel() < info->requiredLevel && !sWorld.getConfig(CONFIG_BOOL_INSTANCE_IGNORE_LEVEL);
+            static constexpr uint32 AllowedLunaticMaps[] = { 36, 43, 389, 822 };
+            bool isLunaticMap = false;
+            for (uint32 mapId : AllowedLunaticMaps)
+                if (targetMap->id == int32(mapId)) { isLunaticMap = true; break; }
+            bool blockedByLevel = levelCheck && !(isLunaticMap && player->HasChallenge(CHALLENGE_LUNATIC));
+            bool blockedByCondition = info->requiredCondition && !IsConditionSatisfied(info->requiredCondition, player, player->GetMap(), player, CONDITION_FROM_AREATRIGGER);
+
+            if (blockedByLevel || blockedByCondition)
+            {
+                if (WorldSession* sess = player->GetSession())
+                {
+                    if (info->message && *info->message)
+                        sess->SendAreaTriggerMessage(info->message);
+                    else if (blockedByLevel)
+                        sess->SendAreaTriggerMessage(sess->GetMangosString(LANG_LEVEL_MINREQUIRED), info->requiredLevel);
+                }
+                return true;
+            }
+
+            if (player->IsInCombat() && targetMap->IsContinent() && player->GetMap()->IsRaid())
+            {
+                if (WorldSession* sess = player->GetSession())
+                    sess->SendAreaTriggerMessage("You are in combat.");
+                return true;
+            }
+        }
+
+        player->TeleportTo(info->dest);
+        return true;
+    }
+};
+
+void AddSC_custom_dungeon_portal()
+{
+    new custom_dungeon_portal();
+}

--- a/src/scripts/world/custom_dungeon_portal.cpp
+++ b/src/scripts/world/custom_dungeon_portal.cpp
@@ -4,10 +4,11 @@
  * See included DOCS/LICENSE.TXT
  *
  * Turtle custom dungeon portal handler — authoritative GameObjectScript for
- * `custom_dungeon_portal`. Destinations and conditions are verbatim from
- * `areatrigger_teleport` (the same table that drives instance areatriggers)
- * and from `map_template`/`instance_template`. No coordinates are invented,
- * no fake success is returned, and no bot-specific coupling is introduced.
+ * `custom_dungeon_portal`. Destinations, levels, conditions, phases and
+ * messages are obtained at use time from `areatrigger_teleport` via
+ * ObjectMgr (the same table that drives instance areatriggers). No
+ * coordinates are invented, no fake success is returned, and no
+ * bot-specific coupling is introduced.
  *
  * Supported entries are those with a proved areatrigger counterpart.
  * All other entries sharing the same script_name remain bound to this script
@@ -22,49 +23,41 @@
 #include "Database/SQLStorages.h"
 #include "Language.h"
 
-struct PortalInfo
+struct PortalTrigger
 {
     uint32 entry;
-    WorldLocation dest;
-    uint8 requiredLevel;
-    uint32 requiredCondition;
-    uint8 requiredPhase;
-    char const* message;
+    uint32 triggerId;
 };
 
-static const PortalInfo* GetPortalInfo(uint32 entry)
+static uint32 GetTriggerIdForEntry(uint32 entry)
 {
-    // Destinations/conditions are verbatim from
-    // sql/base/tw_world_areatrigger_teleport.sql (and its database_updates
-    // mirrors). The trigger IDs cited are the authoritative source — this
-    // file does not invent or offset coordinates.
-    static const PortalInfo infos[] =
+    // Compact GO-entry -> authoritative areatrigger_teleport ID mapping.
+    // All destination/level/condition/phase/message data is fetched from
+    // sObjectMgr.GetAreaTriggerTeleport(triggerId) at use time, so this file
+    // never duplicates coordinates or thresholds.
+    static const PortalTrigger kPortals[] =
     {
-        // Crescent Grove — trigger 5004/5005
-        { 112911, WorldLocation(802,  579.13f,    90.7f,    276.11f,  3.4f),    32, 0, 0, "You must be at least level 32 to enter." },
-        { 112912, WorldLocation(1,    1722.0f, -1272.6f,    163.26f,  5.8f),     0, 0, 0, "" },
-
-        // Black Morass — trigger 1632/1629
-        { 112915, WorldLocation(269, -2002.5f,  6575.3f,   -154.9f,   5.7f),    58, 0, 0, "You must be at least level 58 to enter." },
-        { 112916, WorldLocation(1,   -8756.8f, -4191.3f,   -209.4f,   5.5f),     0, 0, 0, "" },
-
-        // Stormwind Vault — trigger 107/109 (5002/5003 are same entrance)
-        { 112917, WorldLocation(35,    -0.91f,    40.57f,  -24.23f,  1.52f),   58, 0, 0, "You must be at least level 58 to enter." },
-        { 112918, WorldLocation(0,  -8679.12f,  639.337f,  95.819f,  2.29017f),  0, 0, 0, "" },
-
-        // Hateforge Quarry — trigger 5009/5013
-        { 112940, WorldLocation(808, -8173.9f, -3120.6f,   199.8f,   4.7f),    48, 0, 0, "You must be at least level 48 to enter." },
-        { 112941, WorldLocation(0,   -8169.2f, -3106.7f,   200.4f,   1.1f),     0, 0, 0, "" },
-
-        // Karazhan Crypt — trigger 5008/5011
-        { 181580, WorldLocation(800, -11068.1f, -1806.4f,   52.7f,   1.5f),    55, 0, 0, "You must be at least level 55 to enter." },
-        { 181581, WorldLocation(0,   -11068.9f, -1828.6f,   60.26f,  3.1f),     0, 0, 0, "" },
+        // Crescent Grove
+        { 112911, 5004 }, // entrance
+        { 112912, 5005 }, // exit
+        // Black Morass
+        { 112915, 1632 }, // entrance
+        { 112916, 1629 }, // exit
+        // Stormwind Vault (5002/5003 share same dest as 107)
+        { 112917, 107 },  // entrance
+        { 112918, 109 },  // exit
+        // Hateforge Quarry
+        { 112940, 5009 }, // entrance
+        { 112941, 5013 }, // exit
+        // Karazhan Crypt
+        { 181580, 5008 }, // entrance
+        { 181581, 5011 }, // exit
     };
 
-    for (auto const& info : infos)
-        if (info.entry == entry)
-            return &info;
-    return nullptr;
+    for (auto const& p : kPortals)
+        if (p.entry == entry)
+            return p.triggerId;
+    return 0;
 }
 
 class custom_dungeon_portal : public GameObjectScript
@@ -77,9 +70,13 @@ public:
         if (!player || !go)
             return false;
 
-        const PortalInfo* info = GetPortalInfo(go->GetEntry());
-        if (!info)
+        uint32 triggerId = GetTriggerIdForEntry(go->GetEntry());
+        if (!triggerId)
             return true; // intentionally unsupported — consume/fail closed, no teleport, no default GO activation
+
+        AreaTriggerTeleport const* at = sObjectMgr.GetAreaTriggerTeleport(triggerId);
+        if (!at)
+            return true; // authoritative store missing — fail closed, never invent coords
 
         if (player->IsBeingTeleported())
             return true;
@@ -87,14 +84,14 @@ public:
         // Reuse native areatrigger/instance semantics (see
         // WorldSession::HandleAreaTriggerOpcode in Handlers/MiscHandler.cpp).
 
-        MapEntry const* targetMap = sMapStorage.LookupEntry<MapEntry>(info->dest.mapId);
+        MapEntry const* targetMap = sMapStorage.LookupEntry<MapEntry>(at->destination.mapId);
         if (!targetMap)
             return true;
 
-        if (info->requiredPhase > sWorld.GetContentPhase())
+        if (at->requiredPhase > sWorld.GetContentPhase())
         {
             if (WorldSession* sess = player->GetSession())
-                sess->SendAreaTriggerMessage(sess->GetMangosString(LANG_INSTANCE_AVAILABLE_IN_PHASE), info->requiredPhase + 1);
+                sess->SendAreaTriggerMessage(sess->GetMangosString(LANG_INSTANCE_AVAILABLE_IN_PHASE), at->requiredPhase + 1);
             return true;
         }
 
@@ -130,13 +127,13 @@ public:
             // If destination map differs from corpse map, redirect to the
             // corpse's entrance trigger (same as areatrigger logic when
             // possible). Keep authoritative destination otherwise.
-            if (info->dest.mapId != corpseMapId)
+            if (at->destination.mapId != corpseMapId)
             {
                 if (AreaTriggerTeleport const* corpseAt = sObjectMgr.GetMapEntranceTrigger(corpseMapId))
                 {
                     // Use the corpse entrance only when it points into the
                     // same dungeon family; otherwise keep original dest.
-                    if (corpseAt->destination.mapId == info->dest.mapId)
+                    if (corpseAt->destination.mapId == at->destination.mapId)
                     {
                         player->TeleportTo(corpseAt->destination);
                         return true;
@@ -147,22 +144,22 @@ public:
 
         if (!player->IsGameMaster())
         {
-            bool levelCheck = player->GetLevel() < info->requiredLevel && !sWorld.getConfig(CONFIG_BOOL_INSTANCE_IGNORE_LEVEL);
+            bool levelCheck = player->GetLevel() < at->requiredLevel && !sWorld.getConfig(CONFIG_BOOL_INSTANCE_IGNORE_LEVEL);
             static constexpr uint32 AllowedLunaticMaps[] = { 36, 43, 389, 822 };
             bool isLunaticMap = false;
             for (uint32 mapId : AllowedLunaticMaps)
                 if (targetMap->id == int32(mapId)) { isLunaticMap = true; break; }
             bool blockedByLevel = levelCheck && !(isLunaticMap && player->HasChallenge(CHALLENGE_LUNATIC));
-            bool blockedByCondition = info->requiredCondition && !IsConditionSatisfied(info->requiredCondition, player, player->GetMap(), player, CONDITION_FROM_AREATRIGGER);
+            bool blockedByCondition = at->requiredCondition && !IsConditionSatisfied(at->requiredCondition, player, player->GetMap(), player, CONDITION_FROM_AREATRIGGER);
 
             if (blockedByLevel || blockedByCondition)
             {
                 if (WorldSession* sess = player->GetSession())
                 {
-                    if (info->message && *info->message)
-                        sess->SendAreaTriggerMessage(info->message);
+                    if (!at->message.empty())
+                        sess->SendAreaTriggerMessage(at->message.c_str());
                     else if (blockedByLevel)
-                        sess->SendAreaTriggerMessage(sess->GetMangosString(LANG_LEVEL_MINREQUIRED), info->requiredLevel);
+                        sess->SendAreaTriggerMessage(sess->GetMangosString(LANG_LEVEL_MINREQUIRED), at->requiredLevel);
                 }
                 return true;
             }
@@ -175,7 +172,7 @@ public:
             }
         }
 
-        player->TeleportTo(info->dest);
+        player->TeleportTo(at->destination);
         return true;
     }
 };


### PR DESCRIPTION
## Summary
- add a registered `custom_dungeon_portal` GameObjectScript for portal entries with authoritative `areatrigger_teleport` destinations
- preserve native phase, level, condition, ghost, combat, and teleport semantics
- migrate only supported generic portal objects to clickable GOOBER type so the core dispatch path is reachable

## Scope
- Supported mappings use existing areatrigger rows only: Crescent Grove, Black Morass, Stormwind Vault, Hateforge Quarry, and Karazhan Crypt entrances/exits.
- Scarlet Citadel and Caverns of Time placeholders remain bound but return consumed/fail-closed because no authoritative destination exists.
- No invented coordinates, fake success, `script_name=0`, donor race hacks, PlayerBots/RNDBOT coupling, or PR #411 changes.
- SQL migration is idempotent and guarded by the real script name.

## Validation
- scripts and mangosd build previously succeeded at the handler commit; final SQL/dispatch fix reviewed statically.
- focused TU syntax check, authoritative destination comparison, `git diff --check`, and no-bot-coupling audit passed.
- no live click/teleport runtime test was available.