### PR TITLE
BG: expose generic queued-participant demand snapshot

### DIFF
--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1889,7 +1889,8 @@ bool BattleGroundQueue::IsAllQueuesEmpty(BattleGroundBracketId bracket_id)
 // Generic read-only demand snapshot for modules (#42). Copy-only value DTO, no Player pointers.
 std::vector<BattleGroundQueue::QueuedParticipantInfo> BattleGroundQueue::GetQueuedParticipants(BattleGroundBracketId bracketId) const
 {
-    std::lock_guard<std::recursive_mutex> lock(m_Lock);
+    // BattleGroundMgr and its queues are world-thread-owned. Keep this snapshot
+    // on that thread; the existing queue writers do not take m_Lock.
     std::vector<QueuedParticipantInfo> out;
 
     auto appendBracket = [&](BattleGroundBracketId bid)
@@ -1930,49 +1931,12 @@ std::vector<BattleGroundQueue::QueuedParticipantInfo> BattleGroundQueue::GetQueu
     return out;
 }
 
-size_t BattleGroundQueue::GetQueuedParticipantCount(BattleGroundBracketId bracketId, Team team) const
-{
-    std::lock_guard<std::recursive_mutex> lock(m_Lock);
-    size_t count = 0;
-
-    auto countBracket = [&](BattleGroundBracketId bid)
-    {
-        for (uint32 qtype = 0; qtype < BG_QUEUE_GROUP_TYPES_COUNT; ++qtype)
-        {
-            for (GroupQueueInfo const* ginfo : m_QueuedGroups[bid][qtype])
-            {
-                if (!ginfo || ginfo->GroupTeam != team)
-                    continue;
-                count += ginfo->Players.size();
-            }
-        }
-    };
-
-    if (bracketId == BG_BRACKET_ID_NONE)
-    {
-        for (int bid = 0; bid < MAX_BATTLEGROUND_BRACKETS; ++bid)
-            countBracket(BattleGroundBracketId(bid));
-    }
-    else if (bracketId >= 0 && bracketId < MAX_BATTLEGROUND_BRACKETS)
-    {
-        countBracket(bracketId);
-    }
-
-    return count;
-}
 
 std::vector<BattleGroundQueue::QueuedParticipantInfo> BattleGroundMgr::GetQueuedParticipants(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId) const
 {
-    if (queueTypeId >= MAX_BATTLEGROUND_QUEUE_TYPES)
+    if (queueTypeId < BATTLEGROUND_QUEUE_NONE || queueTypeId >= MAX_BATTLEGROUND_QUEUE_TYPES)
         return {};
     return m_BattleGroundQueues[queueTypeId].GetQueuedParticipants(bracketId);
-}
-
-size_t BattleGroundMgr::GetQueuedParticipantCount(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId, Team team) const
-{
-    if (queueTypeId >= MAX_BATTLEGROUND_QUEUE_TYPES)
-        return 0;
-    return m_BattleGroundQueues[queueTypeId].GetQueuedParticipantCount(bracketId, team);
 }
 
 void BattleGroundMgr::AddBattleGround(uint32 InstanceID, BattleGroundTypeId bgTypeId, BattleGround* BG)

--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -1886,6 +1886,95 @@ bool BattleGroundQueue::IsAllQueuesEmpty(BattleGroundBracketId bracket_id)
     return queueEmptyCount == BG_QUEUE_MAX;
 }
 
+// Generic read-only demand snapshot for modules (#42). Copy-only value DTO, no Player pointers.
+std::vector<BattleGroundQueue::QueuedParticipantInfo> BattleGroundQueue::GetQueuedParticipants(BattleGroundBracketId bracketId) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Lock);
+    std::vector<QueuedParticipantInfo> out;
+
+    auto appendBracket = [&](BattleGroundBracketId bid)
+    {
+        for (uint32 qtype = 0; qtype < BG_QUEUE_GROUP_TYPES_COUNT; ++qtype)
+        {
+            for (GroupQueueInfo const* ginfo : m_QueuedGroups[bid][qtype])
+            {
+                if (!ginfo)
+                    continue;
+                for (auto const& kv : ginfo->Players)
+                {
+                    QueuedParticipantInfo info;
+                    info.guid = kv.first;
+                    info.team = ginfo->GroupTeam;
+                    info.bgTypeId = ginfo->BgTypeId;
+                    info.bracketId = ginfo->BracketId;
+                    info.joinTime = ginfo->JoinTime;
+                    info.invitedInstanceId = ginfo->IsInvitedToBGInstanceGUID;
+                    info.isInvited = ginfo->IsInvitedToBGInstanceGUID != 0;
+                    info.online = kv.second ? kv.second->online : false;
+                    out.push_back(info);
+                }
+            }
+        }
+    };
+
+    if (bracketId == BG_BRACKET_ID_NONE)
+    {
+        for (int bid = 0; bid < MAX_BATTLEGROUND_BRACKETS; ++bid)
+            appendBracket(BattleGroundBracketId(bid));
+    }
+    else if (bracketId >= 0 && bracketId < MAX_BATTLEGROUND_BRACKETS)
+    {
+        appendBracket(bracketId);
+    }
+
+    return out;
+}
+
+size_t BattleGroundQueue::GetQueuedParticipantCount(BattleGroundBracketId bracketId, Team team) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_Lock);
+    size_t count = 0;
+
+    auto countBracket = [&](BattleGroundBracketId bid)
+    {
+        for (uint32 qtype = 0; qtype < BG_QUEUE_GROUP_TYPES_COUNT; ++qtype)
+        {
+            for (GroupQueueInfo const* ginfo : m_QueuedGroups[bid][qtype])
+            {
+                if (!ginfo || ginfo->GroupTeam != team)
+                    continue;
+                count += ginfo->Players.size();
+            }
+        }
+    };
+
+    if (bracketId == BG_BRACKET_ID_NONE)
+    {
+        for (int bid = 0; bid < MAX_BATTLEGROUND_BRACKETS; ++bid)
+            countBracket(BattleGroundBracketId(bid));
+    }
+    else if (bracketId >= 0 && bracketId < MAX_BATTLEGROUND_BRACKETS)
+    {
+        countBracket(bracketId);
+    }
+
+    return count;
+}
+
+std::vector<BattleGroundQueue::QueuedParticipantInfo> BattleGroundMgr::GetQueuedParticipants(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId) const
+{
+    if (queueTypeId >= MAX_BATTLEGROUND_QUEUE_TYPES)
+        return {};
+    return m_BattleGroundQueues[queueTypeId].GetQueuedParticipants(bracketId);
+}
+
+size_t BattleGroundMgr::GetQueuedParticipantCount(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId, Team team) const
+{
+    if (queueTypeId >= MAX_BATTLEGROUND_QUEUE_TYPES)
+        return 0;
+    return m_BattleGroundQueues[queueTypeId].GetQueuedParticipantCount(bracketId, team);
+}
+
 void BattleGroundMgr::AddBattleGround(uint32 InstanceID, BattleGroundTypeId bgTypeId, BattleGround* BG)
 {
     std::lock_guard<std::mutex> guard(m_BattleGroundsMutex);

--- a/src/game/Battlegrounds/BattleGroundMgr.h
+++ b/src/game/Battlegrounds/BattleGroundMgr.h
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <mutex>
+#include <type_traits>
 
 #include "Common.h"
 #include "Policies/Singleton.h"
@@ -103,8 +104,30 @@ class BattleGroundQueue
         bool PlayerLoggedIn(Player* player);
         bool IsAllQueuesEmpty(BattleGroundBracketId bracket_id);
 
+        // Generic read-only demand snapshot for modules (#42). Copy-only value DTO, no Player pointers,
+        // no private map exposure. Core retains locks/ownership; snapshot is a flat participant copy.
+        struct QueuedParticipantInfo
+        {
+            ObjectGuid guid;
+            Team team = TEAM_NONE;
+            BattleGroundTypeId bgTypeId = BATTLEGROUND_TYPE_NONE;
+            BattleGroundBracketId bracketId = BG_BRACKET_ID_NONE;
+            uint32 joinTime = 0;
+            uint32 invitedInstanceId = 0;
+            bool isInvited = false;
+            bool online = false;
+            // For transport/headless distinction, module uses the guid for normal lookup:
+            // ObjectAccessor::FindPlayer(guid) -> GetSession() -> HasNetworkTransport()/IsHeadless() when available.
+            // No transport-specific field is baked into the DTO at this baseline; the guid identity suffices
+            // and keeps the API generic and implementation-neutral.
+        };
+
+        // Copy-only, thread-safe via internal lock; core retains ownership. If bracketId == BG_BRACKET_ID_NONE, all brackets.
+        std::vector<QueuedParticipantInfo> GetQueuedParticipants(BattleGroundBracketId bracketId = BG_BRACKET_ID_NONE) const;
+        size_t GetQueuedParticipantCount(BattleGroundBracketId bracketId, Team team) const;
+
         //mutex that should not allow changing private data, nor allowing to update Queue during private data change.
-        std::recursive_mutex m_Lock;
+        mutable std::recursive_mutex m_Lock;
 
 
         typedef std::map<ObjectGuid, PlayerQueueInfo> QueuedPlayersMap;
@@ -247,6 +270,9 @@ class BattleGroundMgr
         BGFreeSlotQueueType BGFreeSlotQueue[MAX_BATTLEGROUND_TYPE_ID];
 
         void ScheduleQueueUpdate(BattleGroundQueueTypeId bgQueueTypeId, BattleGroundTypeId bgTypeId, BattleGroundBracketId bracket_id);
+        // Generic read-only demand snapshot for modules (#42). Delegates to the per-queue snapshot; copy-only value DTO.
+        std::vector<BattleGroundQueue::QueuedParticipantInfo> GetQueuedParticipants(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId = BG_BRACKET_ID_NONE) const;
+        size_t GetQueuedParticipantCount(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId, Team team) const;
         uint32 GetPrematureFinishTime() const;
 
         void ToggleTesting();
@@ -319,5 +345,9 @@ class BattleGroundMgr
 };
 
 extern BattleGroundMgr sBattleGroundMgr;
+
+// Focused static assertions for the generic read-only demand DTO (#42).
+static_assert(std::is_copy_constructible<BattleGroundQueue::QueuedParticipantInfo>::value, "QueuedParticipantInfo must be copy-constructible");
+static_assert(std::is_default_constructible<BattleGroundQueue::QueuedParticipantInfo>::value, "QueuedParticipantInfo must be default-constructible");
 
 #endif

--- a/src/game/Battlegrounds/BattleGroundMgr.h
+++ b/src/game/Battlegrounds/BattleGroundMgr.h
@@ -104,8 +104,8 @@ class BattleGroundQueue
         bool PlayerLoggedIn(Player* player);
         bool IsAllQueuesEmpty(BattleGroundBracketId bracket_id);
 
-        // Generic read-only demand snapshot for modules (#42). Copy-only value DTO, no Player pointers,
-        // no private map exposure. Core retains locks/ownership; snapshot is a flat participant copy.
+        // Generic read-only demand snapshot for modules. Copy-only value DTO, no Player pointers,
+        // no private map exposure. Callers must run on the world thread, which owns queue mutation.
         struct QueuedParticipantInfo
         {
             ObjectGuid guid;
@@ -122,12 +122,11 @@ class BattleGroundQueue
             // and keeps the API generic and implementation-neutral.
         };
 
-        // Copy-only, thread-safe via internal lock; core retains ownership. If bracketId == BG_BRACKET_ID_NONE, all brackets.
+        // Copy-only world-thread snapshot; core retains ownership. If bracketId == BG_BRACKET_ID_NONE, all brackets.
         std::vector<QueuedParticipantInfo> GetQueuedParticipants(BattleGroundBracketId bracketId = BG_BRACKET_ID_NONE) const;
-        size_t GetQueuedParticipantCount(BattleGroundBracketId bracketId, Team team) const;
 
         //mutex that should not allow changing private data, nor allowing to update Queue during private data change.
-        mutable std::recursive_mutex m_Lock;
+        std::recursive_mutex m_Lock;
 
 
         typedef std::map<ObjectGuid, PlayerQueueInfo> QueuedPlayersMap;
@@ -270,9 +269,9 @@ class BattleGroundMgr
         BGFreeSlotQueueType BGFreeSlotQueue[MAX_BATTLEGROUND_TYPE_ID];
 
         void ScheduleQueueUpdate(BattleGroundQueueTypeId bgQueueTypeId, BattleGroundTypeId bgTypeId, BattleGroundBracketId bracket_id);
-        // Generic read-only demand snapshot for modules (#42). Delegates to the per-queue snapshot; copy-only value DTO.
+        // Generic read-only world-thread demand snapshot for modules. Delegates to the per-queue snapshot;
+        // the returned DTOs do not expose queue-owned pointers or maps.
         std::vector<BattleGroundQueue::QueuedParticipantInfo> GetQueuedParticipants(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId = BG_BRACKET_ID_NONE) const;
-        size_t GetQueuedParticipantCount(BattleGroundQueueTypeId queueTypeId, BattleGroundBracketId bracketId, Team team) const;
         uint32 GetPrematureFinishTime() const;
 
         void ToggleTesting();


### PR DESCRIPTION
## Summary
- expose a copy-only `BattleGroundQueue::QueuedParticipantInfo` DTO and `BattleGroundMgr::GetQueuedParticipants`
- let modular policies observe queue type/bracket/team demand without reading private queue structures

## Design
- The snapshot is world-thread-only because existing battleground queue writers are world-thread-owned and do not consistently take the legacy queue mutex. The API makes no false cross-thread safety claim.
- Returned values contain no `Player*`, queue-owned pointers, or bot concepts; core retains all queue ownership and private maps.
- Invalid queue/bracket values fail closed, and unsupported count/speculative helpers are not included.
- PR #411 Headless and PR #413 LFT are untouched.

## Why
The existing public BG data is either non-enumerable/private or exposes internal pointers; a full-world scan is unsuitable for demand-aware module scheduling. This is the smallest generic read-only observation seam needed by TortoiseBots PR #42.

## Validation
- `git diff --check`
- focused structural/API review and bounds checks
- full core build not available in the isolated checkout; no runtime behavior changed or tested.