### PR TITLE
fix: trainers not honoring reqLevel due to dbc data

### DIFF
--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -220,7 +220,7 @@ void WorldSession::SendTrainerList(ObjectGuid guid)
             uint32 triggerSpell = sSpellMgr.GetSpellEntry(tSpell->spell)->EffectTriggerSpell[0];
 
             uint32 reqLevel = 0;
-            if (!_player->IsSpellFitByClassAndRace(tSpell->learnedSpell, &reqLevel))
+            if (!_player->IsSpellFitByClassAndRace(triggerSpell, &reqLevel))
                 continue;
 
             reqLevel = tSpell->isProvidedReqLevel ? tSpell->reqLevel : std::max(reqLevel, tSpell->reqLevel);
@@ -241,7 +241,7 @@ void WorldSession::SendTrainerList(ObjectGuid guid)
             uint32 triggerSpell = sSpellMgr.GetSpellEntry(tSpell->spell)->EffectTriggerSpell[0];
 
             uint32 reqLevel = 0;
-            if (!_player->IsSpellFitByClassAndRace(tSpell->learnedSpell, &reqLevel))
+            if (!_player->IsSpellFitByClassAndRace(triggerSpell, &reqLevel))
                 continue;
 
             reqLevel = tSpell->isProvidedReqLevel ? tSpell->reqLevel : std::max(reqLevel, tSpell->reqLevel);
@@ -319,7 +319,8 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPacket & recv_data)
     
     // Can't be learned, cheat? Or double learn with lags...
     uint32 reqLevel = 0;
-    if (!_player->IsSpellFitByClassAndRace(trainer_spell->learnedSpell, &reqLevel))
+    SpellEntry const* proto = sSpellMgr.GetSpellEntry(trainer_spell->spell);
+    if (!proto || !_player->IsSpellFitByClassAndRace(proto->EffectTriggerSpell[0], &reqLevel))
     {
         SendTrainingFailure(guid, spellId, TRAIN_FAIL_NOT_ENOUGH_SKILL);
         return;
@@ -331,8 +332,6 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPacket & recv_data)
         SendTrainingFailure(guid, spellId, TRAIN_FAIL_NOT_ENOUGH_SKILL);
         return;
     }
-
-    SpellEntry const *proto = sSpellMgr.GetSpellEntry(trainer_spell->spell);
 
     // Apply reputation discount.
     uint32 nSpellCost = uint32(floor(trainer_spell->spellCost * _player->GetReputationPriceDiscount(unit)));

--- a/src/game/Handlers/NPCHandler.cpp
+++ b/src/game/Handlers/NPCHandler.cpp
@@ -40,6 +40,8 @@
 #include "Chat.h"
 #include "CharacterDatabaseCache.h"
 
+#include <algorithm>
+
 enum StableResultCode
 {
     STABLE_ERR_MONEY        = 0x01,                         // "you don't have enough money"
@@ -114,17 +116,8 @@ void WorldSession::HandleTrainerListOpcode(WorldPacket & recv_data)
     SendTrainerList(guid);
 }
 
-static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell, uint32 triggerSpell, TrainerSpellState state, float fDiscountMod, bool can_learn_primary_prof)
+static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell, uint32 triggerSpell, TrainerSpellState state, float fDiscountMod, bool can_learn_primary_prof, uint32 reqLevel)
 {
-    SpellEntry const *triggerInfo = sSpellMgr.GetSpellEntry(triggerSpell);
-    uint32 spellLevel = 0;
-    if (tSpell->reqLevel)
-        spellLevel = tSpell->reqLevel;
-    else if (triggerInfo)
-        spellLevel = triggerInfo->spellLevel;
-    else
-        return;
-
     bool primary_prof_first_rank = sSpellMgr.IsPrimaryProfessionFirstRankSpell(triggerSpell);
 
     SpellChainNode const* chain_node = sSpellMgr.GetSpellChainNode(triggerSpell);
@@ -136,7 +129,7 @@ static void SendTrainerSpellHelper(WorldPacket& data, TrainerSpell const* tSpell
     data << uint32(primary_prof_first_rank && can_learn_primary_prof ? 1 : 0);
     // primary prof. learn confirmation dialog
     data << uint32(primary_prof_first_rank ? 1 : 0);    // must be equal prev. field to have learn button in enabled state
-    data << uint8(spellLevel);
+    data << uint8(reqLevel);
     data << uint32(tSpell->reqSkill);
     data << uint32(tSpell->reqSkillValue);
     // Nostalrius: le client veut spellreq1, spellreq2 avec spellreq2 != 0 seulement si spellreq1 != 0.
@@ -226,12 +219,14 @@ void WorldSession::SendTrainerList(ObjectGuid guid)
 
             uint32 triggerSpell = sSpellMgr.GetSpellEntry(tSpell->spell)->EffectTriggerSpell[0];
 
-            if (!_player->IsSpellFitByClassAndRace(triggerSpell))
+            uint32 reqLevel = 0;
+            if (!_player->IsSpellFitByClassAndRace(tSpell->learnedSpell, &reqLevel))
                 continue;
 
-            TrainerSpellState state = _player->GetTrainerSpellState(tSpell);
+            reqLevel = tSpell->isProvidedReqLevel ? tSpell->reqLevel : std::max(reqLevel, tSpell->reqLevel);
+            TrainerSpellState state = _player->GetTrainerSpellState(tSpell, reqLevel);
 
-            SendTrainerSpellHelper(data, tSpell, triggerSpell, state, fDiscountMod, can_learn_primary_prof);
+            SendTrainerSpellHelper(data, tSpell, triggerSpell, state, fDiscountMod, can_learn_primary_prof, reqLevel);
 
             ++count;
         }
@@ -245,12 +240,14 @@ void WorldSession::SendTrainerList(ObjectGuid guid)
 
             uint32 triggerSpell = sSpellMgr.GetSpellEntry(tSpell->spell)->EffectTriggerSpell[0];
 
-            if (!_player->IsSpellFitByClassAndRace(triggerSpell))
+            uint32 reqLevel = 0;
+            if (!_player->IsSpellFitByClassAndRace(tSpell->learnedSpell, &reqLevel))
                 continue;
 
-            TrainerSpellState state = _player->GetTrainerSpellState(tSpell);
+            reqLevel = tSpell->isProvidedReqLevel ? tSpell->reqLevel : std::max(reqLevel, tSpell->reqLevel);
+            TrainerSpellState state = _player->GetTrainerSpellState(tSpell, reqLevel);
 
-            SendTrainerSpellHelper(data, tSpell, triggerSpell, state, fDiscountMod, can_learn_primary_prof);
+            SendTrainerSpellHelper(data, tSpell, triggerSpell, state, fDiscountMod, can_learn_primary_prof, reqLevel);
 
             ++count;
         }
@@ -321,7 +318,15 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPacket & recv_data)
     }
     
     // Can't be learned, cheat? Or double learn with lags...
-    if (_player->GetTrainerSpellState(trainer_spell) != TRAINER_SPELL_GREEN)
+    uint32 reqLevel = 0;
+    if (!_player->IsSpellFitByClassAndRace(trainer_spell->learnedSpell, &reqLevel))
+    {
+        SendTrainingFailure(guid, spellId, TRAIN_FAIL_NOT_ENOUGH_SKILL);
+        return;
+    }
+
+    reqLevel = trainer_spell->isProvidedReqLevel ? trainer_spell->reqLevel : std::max(reqLevel, trainer_spell->reqLevel);
+    if (_player->GetTrainerSpellState(trainer_spell, reqLevel) != TRAINER_SPELL_GREEN)
     {
         SendTrainingFailure(guid, spellId, TRAIN_FAIL_NOT_ENOUGH_SKILL);
         return;

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -8147,6 +8147,7 @@ void ObjectMgr::LoadTrainers(char const* tableName, bool isTemplates)
         trainerSpell.reqSkill      = fields[3].GetUInt32();
         trainerSpell.reqSkillValue = fields[4].GetUInt32();
         trainerSpell.reqLevel      = fields[5].GetUInt32();
+        trainerSpell.isProvidedReqLevel = trainerSpell.reqLevel > 0;
 
         if (trainerSpell.reqLevel)
         {

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -445,6 +445,7 @@ struct TrainerSpell
     uint32 reqSkill;
     uint32 reqSkillValue;
     uint32 reqLevel;
+    bool isProvidedReqLevel = false;
 };
 
 typedef std::unordered_map<uint32 /*spellid*/, TrainerSpell> TrainerSpellMap;

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -5267,7 +5267,7 @@ bool Player::HasActiveSpell(uint32 spell) const
             itr->second.active && !itr->second.disabled);
 }
 
-TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell) const
+TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell, uint32 reqLevel) const
 {
     if (!trainer_spell)
         return TRAINER_SPELL_RED;
@@ -5284,13 +5284,15 @@ TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell
     if (HasSpell(TriggerSpell->Id))
         return TRAINER_SPELL_GRAY;
 
-    // check race/class requirement
-    if (!IsSpellFitByClassAndRace(TriggerSpell->Id))
+    // Check race/class eligibility without applying the DBC level requirement.
+    uint32 skillReqLevel = 0;
+    if (!IsSpellFitByClassAndRace(TriggerSpell->Id, &skillReqLevel))
         return TRAINER_SPELL_RED;
 
     // check level requirement
-    uint32 spellLevel = trainer_spell->reqLevel ? trainer_spell->reqLevel : TriggerSpell->spellLevel;
-    if (GetLevel() < spellLevel)
+    if (!reqLevel)
+        reqLevel = trainer_spell->isProvidedReqLevel ? trainer_spell->reqLevel : std::max(skillReqLevel, trainer_spell->reqLevel);
+    if (GetLevel() < reqLevel)
         return TRAINER_SPELL_RED;
 
     if (SpellChainNode const* spell_chain = sSpellMgr.GetSpellChainNode(TriggerSpell->Id))

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1711,7 +1711,7 @@ class Player final: public Unit
     public:
         bool HasSpell(uint32 spell) const override;
         bool HasActiveSpell(uint32 spell) const;            // show in spellbook
-        TrainerSpellState GetTrainerSpellState(TrainerSpell const* trainer_spell) const;
+        TrainerSpellState GetTrainerSpellState(TrainerSpell const* trainer_spell, uint32 reqLevel = 0) const;
         bool IsSpellFitByClassAndRace(uint32 spell_id, uint32* pReqlevel = nullptr) const;
         bool IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex index, bool castOnSelf) const override;
         void ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs) override;


### PR DESCRIPTION
## Issue this resolves
<!-- Please link to an issue. Create one first if needed. -->
- Closes #417 

## Code Type
- [ ]  SQL
- [ x]  Core

## Description
While the DB had correct reqLevel, `IsSpellFitByClassAndRace` was checked first which included a check on level included in dbc data. We need to provide the overridden reqLevel here to prevent returning early as an unavailable spell
