### PR TITLE
Fix Starbreeze Village Water Barrel position

### DIFF
--- a/sql/wip_updates/gameobject.sql
+++ b/sql/wip_updates/gameobject.sql
@@ -1,0 +1,5 @@
+-- Move the Starbreeze Village Water Barrel slightly into the room so the
+-- Nightelf2Story.wmo wall no longer blocks legitimate indoor interaction.
+UPDATE `gameobject`
+SET `position_y` = 446.778
+WHERE `guid` = 49614 AND `id` = 3658;


### PR DESCRIPTION
## Issue this resolves

- Closes #428

## Code Type

- [x] SQL
- [ ] Core

## Description

The issue appears to be caused by the building's collision geometry extending beyond the visible wall and blocking line of sight to the water barrel.

This change moves the barrel slightly farther into the room, allowing it to be looted from the intended room side.

Only Water Barrel spawn GUID `49614`, gameobject entry `3658`, is changed:

- Old position: `9824.22, 447.278, 1307.79`
- New position: `9824.22, 446.778, 1307.79`

The overlapping Food Crate is not modified.

## Testing

Tested with1.18.1 build 7272 with current main tortoise core.

- Confirmed that interacting at the original position reports `Target not in line of sight`.
- Moved the barrel from Y `447.278` to `446.778`.
- Confirmed that the barrel can be looted from the room side.