### PR TITLE
Items: an unlisted spell category is a note, not a database error

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -2531,8 +2531,14 @@ void ObjectMgr::LoadItemPrototypes()
 
                 if (proto->Spells[j].SpellCategory > 0)
                 {
+                    // An item's spell category is a free-form grouping key for shared
+                    // cooldowns: the value is only ever used as a map key by
+                    // Unit::HasSpellCategoryCooldown, never looked up in SpellCategory.dbc
+                    // (this is that store's only reader in the whole core). A category the
+                    // DBC does not list still works, so this is a note, not a fault - the
+                    // value is deliberately left in place rather than cleared.
                     if (!sSpellCategoryStore.LookupEntry(proto->Spells[j].SpellCategory))
-                        sLog.outErrorDb("Item (Entry: %u) has wrong (not existing) spell category in spellcategory_%d (%u)", i, j + 1, proto->Spells[j].SpellCategory);
+                        sLog.outDetail("Item (Entry: %u) has spell category in spellcategory_%d (%u) that is not listed in SpellCategory.dbc", i, j + 1, proto->Spells[j].SpellCategory);
                 }
             }
         }


### PR DESCRIPTION
## Issue this resolves

- Closes #460

## Code Type

- [ ] SQL
- [x] Core

## Description

`ObjectMgr::LoadItemPrototypes`: an unlisted item spell category moves from `outErrorDb` to `outDetail`, and the value is deliberately left in place (the `SpellId` check right above this one clears an unknown spell, but doing the same here would break the shared cooldowns of ~185 item slots - category 1153 alone groups Healthstones, Mana Gems, Thistle Tea and target dummies onto one shared cooldown). `sSpellCategoryStore` has exactly one reader in the whole core - this check - and the value is otherwise only ever used as an in-memory grouping key, never looked up in `SpellCategory.dbc` again.

`SpellCategory.dbc` stays on the load list: a missing or wrong-client copy is still caught structurally by `LoadDBC` (field count vs format) and still refuses the boot, independent of this check.

Compiled and boot-tested on Penqle `1181dev` - the ~185 lines this produced on a clean boot are gone, no other behavior change.
