### PR TITLE
Containers: recognize Turtle's mining/leatherworking/rations/fishing bags

### DIFF
--- a/src/game/Objects/Item.cpp
+++ b/src/game/Objects/Item.cpp
@@ -198,6 +198,22 @@ bool ItemCanGoIntoBag(ItemPrototype const* pProto, ItemPrototype const* pBagProt
                     if (pProto->BagFamily != BAG_FAMILY_ENGINEERING_SUPP)
                         return false;
                     return true;
+                case ITEM_SUBCLASS_MINING_CONTAINER:
+                    if (pProto->BagFamily != BAG_FAMILY_MINING)
+                        return false;
+                    return true;
+                case ITEM_SUBCLASS_LEATHERWORKING_CONTAINER:
+                    if (pProto->BagFamily != BAG_FAMILY_LEATHER)
+                        return false;
+                    return true;
+                case ITEM_SUBCLASS_RATIONS_CONTAINER:
+                    if (pProto->BagFamily != BAG_FAMILY_MEAT)
+                        return false;
+                    return true;
+                case ITEM_SUBCLASS_FISHING_CONTAINER:
+                    if (pProto->BagFamily != BAG_FAMILY_FISH)
+                        return false;
+                    return true;
             }
             return false;
         case ITEM_CLASS_QUIVER:

--- a/src/game/Objects/ItemPrototype.h
+++ b/src/game/Objects/ItemPrototype.h
@@ -104,6 +104,10 @@ enum BagFamily
     BAG_FAMILY_ENCHANTING_SUPP                  = 7,
     BAG_FAMILY_ENGINEERING_SUPP                 = 8,
     BAG_FAMILY_KEYS                             = 9,
+    BAG_FAMILY_MEAT                             = 10, // Turtle: rations bags
+    BAG_FAMILY_FISH                             = 11, // Turtle: fishing bags
+    BAG_FAMILY_LEATHER                          = 12, // Turtle: leatherworking bags
+    BAG_FAMILY_MINING                           = 13, // Turtle: mining bags (ore, stone, gems)
 };
 
 enum InventoryType
@@ -187,10 +191,12 @@ enum ItemSubclassContainer
     ITEM_SUBCLASS_ENGINEERING_CONTAINER = 4,
     ITEM_SUBCLASS_GEM_CONTAINER = 5,
     ITEM_SUBCLASS_MINING_CONTAINER = 6,
-    ITEM_SUBCLASS_LEATHERWORKING_CONTAINER = 7
+    ITEM_SUBCLASS_LEATHERWORKING_CONTAINER = 7,
+    ITEM_SUBCLASS_RATIONS_CONTAINER = 8,  // Turtle: rations bags (BAG_FAMILY_MEAT)
+    ITEM_SUBCLASS_FISHING_CONTAINER = 9   // Turtle: fishing bags (BAG_FAMILY_FISH)
 };
 
-#define MAX_ITEM_SUBCLASS_CONTAINER 8
+#define MAX_ITEM_SUBCLASS_CONTAINER 10
 
 enum ItemSubclassWeapon
 {


### PR DESCRIPTION
## Issue this resolves

- Closes #466

## Code Type

- [ ] SQL
- [x] Core

## Description

`ItemPrototype.h`: names subclasses 8/9 (`ITEM_SUBCLASS_RATIONS_CONTAINER`/`FISHING_CONTAINER`) and raises `MAX_ITEM_SUBCLASS_CONTAINER` to 10; names `BagFamily` 10-13 (`MEAT`/`FISH`/`LEATHER`/`MINING`) instead of leaving them as bare numbers already accepted by `ItemBagFamily.dbc`.

`Item.cpp`, `ItemCanGoIntoBag()`: adds the four missing cases (subclass 6/7/8/9), each pairing the subclass with the one `BagFamily` every item carrying it actually uses.

Subclass 5 (gem container) is left unhandled: no item in the database uses it, and ore/gems both carry `BAG_FAMILY_MINING` (13), so there's no item-level evidence for what a separate gem family would mean here.

No data changes needed - the 14 affected items already exist with the right `BagFamily` (added by `20260505222630_world.sql` and `20260816173710_world.sql`); this PR is purely the core-side plumbing to recognize them.

Compiled and boot-tested on Penqle `1181dev` - all 8 startup warnings gone. Also manually verified in-game against a live client/server built from this branch: Copper Ore sorts into Miner's Rucksack, Light Leather into Skinner's Pack, Goretusk Liver into Makeshift Ration Bag, Slitherskin Mackerel into Fishing Bag, and each bag rejects items outside its own family.
