### PR TITLE
Fix chat channel ID loading and name matching

### DIFF
--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -10175,31 +10175,38 @@ ChatChannelsEntry const* ObjectMgr::GetChannelEntryFor(std::string const& name)
 {
     for (auto const& itr : m_chatChannelsMap)
     {
-        // need to remove %s from entryName if it exists before we match
-        for (const auto loc : itr.second.name)
+        for (std::string const& entryName : itr.second.name)
         {
-            std::string entryName(loc);
-            std::size_t removeString = entryName.find("%s");
-
             // Not loaded locale
             if (entryName.empty())
                 continue;
 
-            if (removeString != std::string::npos)
-                entryName.replace(removeString, 2, "");
+            std::size_t const zoneMarker = entryName.find("%s");
+            if (zoneMarker == std::string::npos)
+            {
+                if (entryName == name)
+                    return &itr.second;
+                continue;
+            }
 
-            if (name.find(entryName) != std::string::npos)
+            std::string const prefix = entryName.substr(0, zoneMarker);
+            std::string const suffix = entryName.substr(zoneMarker + 2);
+            if (name.size() < prefix.size() + suffix.size())
+                continue;
+
+            if (name.compare(0, prefix.size(), prefix) == 0 &&
+                name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
                 return &itr.second;
         }
 
         // search in shortcut name
-        for (const auto loc : itr.second.shortcut)
+        for (std::string const& shortcut : itr.second.shortcut)
         {
             // Not loaded locale
-            if (loc.empty())
+            if (shortcut.empty())
                 continue;
 
-            if (loc == name)
+            if (shortcut == name)
                 return &itr.second;
         }
     }

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -10146,7 +10146,7 @@ void ObjectMgr::LoadChatChannels()
 
         uint32 id = fields[0].GetUInt32();
         ChatChannelsEntry channel;
-        channel.id = 1;
+        channel.id = id;
         channel.flags = fields[1].GetUInt32();
         channel.factionGroup = fields[2].GetUInt32();
 


### PR DESCRIPTION
## Summary

This PR fixes two issues in chat channel loading and lookup:

* Uses the actual channel ID loaded from the database instead of assigning `1` to every `ChatChannelsEntry`.
* Makes channel name matching more precise:

  * Static channel names must match exactly.
  * Channel names containing `%s` are matched by prefix and suffix around the dynamic zone name.
  * Shortcut names continue to use exact matching.

## Details

### Chat channel IDs

`ObjectMgr::LoadChatChannels()` already reads the channel ID from the database, but the loaded value was ignored and every entry was assigned `1`.

The loaded database ID is now assigned to `channel.id`.

### Chat channel name matching

`ObjectMgr::GetChannelEntryFor()` previously removed `%s` from localized channel names and then used a substring search.

This could produce false matches when the remaining channel name occurred only as a substring of another channel name.

The lookup now distinguishes between:

* Names without `%s`, which require an exact match.
* Names with `%s`, which require both the prefix and suffix around the placeholder to match.

This preserves support for dynamic zone-based channel names while avoiding broad substring matches.

## Scope

The changes are limited to chat channel loading and channel name lookup.
