### PR TITLE
Script hooks for bot modules

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -53,6 +53,16 @@ set(MODULES_COMMON_INCLUDES
   ${CMAKE_SOURCE_DIR}/src/game/Threat
   ${CMAKE_SOURCE_DIR}/src/game/Transports
   ${CMAKE_SOURCE_DIR}/src/game/vmap
+  ${CMAKE_SOURCE_DIR}/src/game/LFT
+  ${CMAKE_SOURCE_DIR}/src/game/MapNodes
+  ${CMAKE_SOURCE_DIR}/src/game/PacketBroadcast
+  ${CMAKE_SOURCE_DIR}/src/game/Logging
+  ${CMAKE_SOURCE_DIR}/src/game/Shop
+  ${CMAKE_SOURCE_DIR}/src/game/TWDebuff
+  ${CMAKE_SOURCE_DIR}/src/game/GuildBank
+  ${CMAKE_SOURCE_DIR}/src/game/HttpApi
+  ${CMAKE_SOURCE_DIR}/src/game/DiscordBot
+  ${CMAKE_SOURCE_DIR}/src/game/Analysis
   ${CMAKE_SOURCE_DIR}/dep/include
   ${CMAKE_SOURCE_DIR}/dep/recastnavigation
   ${CMAKE_SOURCE_DIR}/dep/include/g3dlite

--- a/src/game/Chat/Channel.cpp
+++ b/src/game/Chat/Channel.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "Channel.h"
+#include "ScriptObjects.h"
 #include "ObjectMgr.h"
 #include "World.h"
 #include "SocialMgr.h"
@@ -703,6 +704,11 @@ void Channel::Say(ObjectGuid guid, const char *text, uint32 lang, bool skipCheck
 
 void Channel::AsyncSay(ObjectGuid guid, const char* what, uint32 lang /*= LANG_UNIVERSAL*/, bool skipCheck /*= false*/)
 {
+    // Said by somebody with no client. Taken here, on the caller's thread, rather than in the
+    // broadcaster that consumes the queue on another one.
+    ScriptRegistry<WorldScript>::ForEachEnabledHook(WORLDHOOK_ON_CHANNEL_BROADCAST,
+        [&](WorldScript* s) { s->OnChannelBroadcast(guid.GetCounter(), GetName().c_str(), what); });
+
     sWorld.GetChannelBroadcaster()->EnqueueMessage(what, GetName(), guid, lang, GetTeam(), skipCheck);
 }
 

--- a/src/game/Chat/ChannelMgr.h
+++ b/src/game/Chat/ChannelMgr.h
@@ -43,6 +43,8 @@ class ChannelMgr
 
         Channel *GetOrCreateChannel(std::string const& name, bool allowAreaDependantChans = true);
         Channel *GetChannel(std::string const& name, PlayerPointer p, bool pkt = true);
+        // Read access for modules: every channel of this faction.
+        ChannelMap const& GetChannels() const { return channels; }
         void LeftChannel(std::string const& name);
         void CreateDefaultChannels();
         static void AnnounceBothFactionsChannel(std::string const& channelName, ObjectGuid playerGuid, char const* message);

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -1384,7 +1384,7 @@ void ChatHandler::CheckIntegrity(ChatCommand *table, ChatCommand *parentCommand)
 
         if (command->ChildCommands)
         {
-            if (command->Handler)
+            if (command->Handler || command->ModuleHandler)
             {
                 if (parentCommand)
                     sLog.outError("Subcommand '%s' of command '%s' have handler and subcommands in same time, must be used '' subcommand for handler instead.",
@@ -1399,7 +1399,7 @@ void ChatHandler::CheckIntegrity(ChatCommand *table, ChatCommand *parentCommand)
 
             CheckIntegrity(command->ChildCommands, command);
         }
-        else if (!command->Handler)
+        else if (!command->Handler && !command->ModuleHandler)
         {
             if (parentCommand)
                 sLog.outError("Subcommand '%s' of command '%s' not have handler and subcommands in same time. Must have some from its!",
@@ -1526,7 +1526,7 @@ ChatCommandSearchResult ChatHandler::FindCommand(ChatCommand* table, char const*
         }
 
         // must be have handler is explicitly selected
-        if (!table[i].Handler)
+        if (!table[i].Handler && !table[i].ModuleHandler)
             continue;
 
         // command found directly in to table
@@ -1660,7 +1660,10 @@ void ChatHandler::ExecuteCommand(const char* text)
                 }
             }
 
-            if ((this->*(command->Handler))((char*)text))   // text content destroyed at call
+            bool const handled = command->ModuleHandler
+                ? command->ModuleHandler(this, (char*)text)
+                : (this->*(command->Handler))((char*)text);   // text content destroyed at call
+            if (handled)
             {
                 if (m_session && command->Flags & COMMAND_FLAGS_CRITICAL)
                 {

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -71,6 +71,8 @@ public:
         uint8              Flags;
         std::string        FullName;
         uint32             PermissionMask = 0;
+        // A module binds a free function here; Handler is the core's member pointer.
+        bool             (*ModuleHandler)(ChatHandler* handler, char* args) = nullptr;
 };
 
 enum ChatCommandSearchResult

--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -1023,6 +1023,16 @@ void Group::StartLootRoll(Creature* lootTarget, LootMethod method, Loot* loot, u
         loot->items[itemSlot].is_blocked = true;
         lootTarget->StartGroupLoot(this, LOOT_ROLL_TIMEOUT);
         RollId.push_back(r);
+
+        // The managed bots vote now rather than never. They have no client to
+        // send CMSG_LOOT_ROLL, so before this every roll they were part of ran
+        // its full thirty seconds and passed by default.
+        //
+        // After RollId.push_back on purpose: CountRollVote looks the roll up in
+        // that list, and a vote cast before it is in there finds nothing.
+        ScriptRegistry<GroupScript>::ForEach([&](GroupScript* s) {
+            s->OnLootRollStarted(this, lootTarget->GetObjectGuid(), itemSlot, lootItem.itemid);
+        });
     }
     else                                            // no looters??
         delete r;

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -324,6 +324,10 @@ void WorldSession::HandlePlayerLoginOpcode(WorldPacket & recv_data)
         return;
     }
 
+    // Module hook: a bot session holding this character yields to the real client
+    // logging in.
+    ScriptRegistry<WorldScript>::ForEachEnabledHook(WORLDHOOK_ON_BOT_LOGIN_YIELD,
+        [&](WorldScript* s) { s->OnBotLoginYield(playerGuid.GetCounter()); });
     // A real client always wins. Pending/Loading Headless sessions have not
     // materialized a Player yet, so cancel them before dispatching this login.
     if ((headlessState == HeadlessSessionState::Pending ||

--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -292,6 +292,11 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
         case CHAT_MSG_HARDCORE:
         {
             recv_data >> msg;
+
+            // A module may take an addon message as a command of its own.
+            if (lang == LANG_ADDON && _player && sScriptMgr.OnAddonMessage(_player, msg))
+                return;
+
             if (!ProcessChatMessageAfterSecurityCheck(msg, lang, type))
                 return;
             if (msg.empty())
@@ -470,10 +475,27 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
                         }
                     }
 
+                    // Somebody asking for a group in the channel where one asks
+                    // for a group, or for an enchant where enchants are traded.
+                    //
+                    // Above the antispam rather than inside it. AddMessage
+                    // returning false does not mean the message was refused --
+                    // it means it went onto the off-thread queue to be delivered
+                    // a moment later, which is what happens to everybody at or
+                    // below Antispam.RestrictionLevel. Hooked inside that branch,
+                    // managed bots were deaf to exactly the players likeliest to
+                    // be asking for something: the new ones. The reply that never
+                    // came looked like every other kind of bug, and cost most of
+                    // a morning.
+                    if (_player)
+                        ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CHAT_CHANNEL,
+                            [&](PlayerScript* s) { s->OnChatChannel(_player, channel.c_str(), msg.c_str()); });
+
                     AntispamInterface* pAntispam = sAnticheatLib->GetAntispam();
                     if (lang == LANG_ADDON || !pAntispam || pAntispam->AddMessage(msg, lang, type, GetPlayerPointer(), nullptr, chn, nullptr))
                     {
                         chn->AsyncSay(playerPointer->GetObjectGuid(), msg.c_str(), lang);
+
 
                         if (lang != LANG_ADDON && bIsWorldChannel)
                         {
@@ -513,6 +535,12 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
                 return;
 
             GetPlayer()->Say(msg, lang);
+
+            // Speech names nobody, so at most one managed bot nearby looks up.
+            if (lang != LANG_ADDON)
+                ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CHAT_SAY,
+                    [&](PlayerScript* s) { s->OnChatSay(GetPlayer(),
+                        sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_SAY), msg.c_str()); });
 
             if (lang != LANG_ADDON)
             {
@@ -626,6 +654,13 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
                 //if (!allowSendWhisper || lang == LANG_ADDON || !pAntispam || pAntispam->AddMessage(msg, lang, type, GetPlayerPointer(), PlayerPointer(new PlayerWrapper<MasterPlayer>(player)), nullptr, nullptr))
                 masterPlr->Whisper(msg, lang, player, allowSendWhisper);
 
+                // A module listens to whispers and party chat for one thing only:
+                // somebody calling an errand off. Everything else it is told
+                // arrives through a channel.
+                if (_player)
+                    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CHAT_WHISPER,
+                        [&](PlayerScript* s) { s->OnChatWhisper(_player, msg.c_str()); });
+
                 if (lang != LANG_ADDON)
                 {
                     sWorld.LogChat(this, "Whisp", msg, PlayerPointer(new PlayerWrapper<MasterPlayer>(player)));
@@ -645,6 +680,10 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
                     return;
             }
 
+            if (_player)
+                ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CHAT_WHISPER,
+                    [&](PlayerScript* s) { s->OnChatWhisper(_player, msg.c_str()); });
+
             WorldPacket data;
             ChatHandler::BuildChatPacket(data, ChatMsg(type), msg.c_str(), Language(lang), _player->GetChatTag(), _player->GetObjectGuid(), _player->GetName());
 
@@ -659,6 +698,13 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
             if (Guild* guild = sGuildMgr.GetGuildById(GetMasterPlayer()->GetGuildId()))
             {
                 guild->BroadcastToGuild(this, msg, lang == LANG_ADDON ? LANG_ADDON : LANG_UNIVERSAL);
+
+                // Module hook: guild chat with our people in it answers back.
+                if (_player && lang != LANG_ADDON)
+                {
+                    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CHAT_GUILD,
+                        [&](PlayerScript* s) { s->OnChatGuild(_player, msg.c_str()); });
+                }
             }
 
             if (lang != LANG_ADDON)
@@ -975,6 +1021,12 @@ void WorldSession::HandleTextEmoteOpcode(WorldPacket & recv_data)
     //Send scripted event call
     if (unit && unit->IsCreature() && ((Creature*)unit)->AI())
         ((Creature*)unit)->AI()->ReceiveEmote(GetPlayer(), textEmote);
+
+    // And the same courtesy for managed bots. The packet carried its target, so
+    // this is the one place in the game where who was addressed is not a
+    // guess -- no distance heuristic, no name parsing, no language involved.
+    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_TEXT_EMOTE_HEARD,
+        [&](PlayerScript* s) { s->OnTextEmoteHeard(GetPlayer(), textEmote, guid); });
 }
 
 void WorldSession::HandleChatIgnoredOpcode(WorldPacket& recv_data)

--- a/src/game/Handlers/GuildHandler.cpp
+++ b/src/game/Handlers/GuildHandler.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "Common.h"
+#include "ScriptObjects.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "World.h"
@@ -133,6 +134,10 @@ void WorldSession::HandleGuildInviteOpcode(WorldPacket& recvPacket)
     data << GetPlayer()->GetName();
     data << guild->GetName();
     player->GetSession()->SendPacket(&data);
+
+    // Module hook: a managed bot has no client to click the invite window; the
+    // module answers for it a moment later.
+    ScriptRegistry<GuildScript>::ForEach([&](GuildScript* s) { s->OnGuildInvite(player); });
 
     DEBUG_LOG("WORLD: Sent (SMSG_GUILD_INVITE)");
 }

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -231,7 +231,15 @@ public:
                 break;
         }
 
-        uint32 count = m.size();
+        const uint32 fromShadows = sScriptMgr.AppendWhoResults(data, clientcount,
+                                                 level_min, level_max,
+                                                 racemask, classmask,
+                                                 zones_count, zoneids,
+                                                 (uint32)team, allowTwoSideWhoList,
+                                                 wplayer_name);
+        clientcount += fromShadows;
+
+        uint32 count = m.size() + fromShadows;
         data.put(0, clientcount);                               // insert right count, listed count
         data.put(4, count > 49 ? count : clientcount);          // insert right count, online count
 
@@ -243,15 +251,11 @@ public:
 void WorldSession::HandleWhoOpcode(WorldPacket & recv_data)
 {
     DEBUG_LOG("WORLD: Recvd CMSG_WHO Message");
-    if (ReceivedWhoRequest())
-        return;
     //recv_data.hexlike();
 
     time_t t = time(nullptr);
 
 
-    if (t - m_lastWhoRequest < 30 && !(GetPlayer() && GetPlayer()->HasCustomFlag(CUSTOM_PLAYER_FLAG_BYPASS_WHO_COOLDOWN)))
-        return;
 
     std::string player_name, guild_name;
 
@@ -265,6 +269,18 @@ void WorldSession::HandleWhoOpcode(WorldPacket & recv_data)
     recv_data >> TaskLevelMin;                               // maximal player level, default 0
     recv_data >> TaskLevelMax;                               // minimal player level, default 100 (MAX_LEVEL)
     recv_data >> player_name;                                   // player name, case sensitive...
+
+    // A module may take the search text as a command of its own -- an addon that
+    // cannot speak can still search. Before the throttle on purpose: commands are
+    // not searches.
+    if (GetPlayer() && sScriptMgr.OnWhoRequest(GetPlayer(), player_name))
+        return;
+
+    if (ReceivedWhoRequest())
+        return;
+
+    if (t - m_lastWhoRequest < 30 && !(GetPlayer() && GetPlayer()->HasCustomFlag(CUSTOM_PLAYER_FLAG_BYPASS_WHO_COOLDOWN)))
+        return;
 
     recv_data >> guild_name;                                    // guild name, case sensitive...
 

--- a/src/game/LFG/LFGMgr.h
+++ b/src/game/LFG/LFGMgr.h
@@ -95,6 +95,13 @@ class LFGQueue
         void AddToQueue(Player* leader, uint32 queAreaID);
         void RestoreOfflinePlayer(Player* player);
         bool IsPlayerInQueue(const ObjectGuid& plrGuid) const;
+        // Read access for modules: the queue entry of one player, if queued.
+        void GetPlayerQueueInfo(LFGPlayerQueueInfo* info, ObjectGuid plrGuid) const
+        {
+            auto it = m_QueuedPlayers.find(plrGuid);
+            if (it != m_QueuedPlayers.end() && info)
+                *info = it->second;
+        }
         void RemovePlayerFromQueue(const ObjectGuid& plrGuid, PlayerLeaveMethod leaveMethod = PLAYER_CLIENT_LEAVE); // 0 == by default system (cmsg, leader leave), 1 == by lfg system (no need report text you left queu)
         void RemoveGroupFromQueue(uint32 groupId, GroupLeaveMethod leaveMethod = GROUP_CLIENT_LEAVE);
         void Update(uint32 diff);

--- a/src/game/LFT/LFTMgr.cpp
+++ b/src/game/LFT/LFTMgr.cpp
@@ -131,8 +131,17 @@ void LFTManager::Update(uint32 diff)
     TryMakeOffers();
 }
 
+uint8 LFTManager::SignedUpRole(ObjectGuid const& guid) const
+{
+    std::map<ObjectGuid, uint8>::const_iterator it = m_signedUpRole.find(guid);
+
+    return it == m_signedUpRole.end() ? 0 : it->second;
+}
+
 void LFTManager::OnPlayerLogout(ObjectGuid const& guid)
 {
+    m_signedUpRole.erase(guid);
+
     EnsureListingsLoaded();
     CleanupPlayer(guid);
 

--- a/src/game/LFT/LFTMgr.h
+++ b/src/game/LFT/LFTMgr.h
@@ -29,6 +29,10 @@ class LFTManager
         bool HandleAddonMessage(Player* player, uint32 type, std::string const& rawMessage);
         void Update(uint32 diff);
         void OnPlayerLogout(ObjectGuid const& guid);
+        // What somebody signed up as, kept after the queue has let go of them: a
+        // group forming is the moment anybody asks. Cleared on logout.
+        uint8 SignedUpRole(ObjectGuid const& guid) const;
+
 
         // Generic module API: queue a live in-world player through native validation.
         // World-thread only. Validates instances and role (via AllowedRoleMask, native
@@ -137,6 +141,9 @@ class LFTManager
 
         typedef std::map<uint32, Listing> ListingsMap;
         typedef std::map<ObjectGuid, QueuedPlayer> QueueMap;
+        // Survives the queue entry it came from; cleared on logout.
+        std::map<ObjectGuid, uint8> m_signedUpRole;
+
         typedef std::map<ObjectGuid, PendingRolecheck> RolecheckMap;
         typedef std::map<uint32, Offer> OffersMap;
 

--- a/src/game/LFT/LFTQeueue.cpp
+++ b/src/game/LFT/LFTQeueue.cpp
@@ -1,3 +1,4 @@
+#include "ScriptMgr.h"
 #include "LFTMgr.h"
 
 #include "Group.h"
@@ -62,6 +63,11 @@ namespace
 
 void LFTManager::HandleQueueJoin(Player* player, std::vector<std::string> const& fields)
 {
+    // A managed bot never queues on its own behalf: a group formed for one steals
+    // members from groups formed for people, and nobody at the other end wanted it.
+    if (player && sScriptMgr.IsBotManaged(player))
+        return;
+
     if (fields.size() < 3)
         return;
 
@@ -239,9 +245,42 @@ void LFTManager::StartRolecheck(Player* leader, std::vector<std::string> const& 
     {
         if (Player* member = GetPlayer(guid))
         {
+            // A managed bot answers for itself, here and now.
+            //
+            // The rolecheck is an addon conversation: the server asks every member
+            // what they want to be, the addon opens a window, somebody clicks. A
+            // managed bot has no client and therefore no window and no click, so it
+            // never answered -- and because the check only completes when everybody
+            // has, a party with a managed bot in it could not list itself at all. It
+            // waited ninety seconds and expired, every time.
+            //
+            // The module knows its role, the same answer it would give in any group.
+            // There is nothing to ask and nobody to ask, so
+            // the response is simply written down, and no message is sent to a client
+            // that does not exist.
+            if (sScriptMgr.IsBotManaged(member))
+            {
+                if (uint8 roles = sScriptMgr.GetBotRoles(member))
+                    m_rolechecks[rolecheck.leaderGuid].responses[guid] = roles;
+
+                continue;
+            }
+
             Send(member, "S2C_ROLECHECK_START;" + joinedInstances);
             Send(member, "S2C_UPDATE_QUEUE_STATUS;pending_rolecheck");
         }
+    }
+
+    // And if that was everybody -- a party of managed bots with nobody left to ask -- the
+    // check is already finished rather than pending.
+    RolecheckMap::iterator itr = m_rolechecks.find(rolecheck.leaderGuid);
+
+    if (itr != m_rolechecks.end() &&
+        itr->second.responses.size() == itr->second.members.size())
+    {
+        PendingRolecheck finished = itr->second;
+        m_rolechecks.erase(itr);
+        EnqueueRolecheck(finished);
     }
 }
 
@@ -263,6 +302,7 @@ void LFTManager::EnqueuePlayer(Player* player, ObjectGuid const& leaderGuid, std
     queued.instances = instances;
     queued.roleMask = roleMask;
     queued.assignedRole = PickRole(roleMask, 0, 0, 0);
+    m_signedUpRole[queued.guid] = queued.assignedRole;   // outlives the queue entry
 
     m_queue[queued.guid] = queued;
     SendQueueJoined(player, m_queue[queued.guid]);
@@ -314,6 +354,7 @@ void LFTManager::CancelOffer(uint32 offerId, bool requeueAccepted, ObjectGuid co
         if (keepQueued && queued != m_queue.end())
         {
             queued->second.assignedRole = PickRole(queued->second.roleMask, 0, 0, 0);
+            m_signedUpRole[queued->first] = queued->second.assignedRole;
             if (Player* player = GetPlayer(itr->first))
                 SendQueueJoined(player, queued->second);
         }
@@ -462,6 +503,7 @@ bool LFTManager::TryBuildOfferForInstance(std::string const& instance)
     for (std::map<ObjectGuid, uint8>::const_iterator itr = selectedRoles.begin(); itr != selectedRoles.end(); ++itr)
     {
         m_queue[itr->first].assignedRole = itr->second;
+        m_signedUpRole[itr->first] = itr->second;
         m_playerOffers[itr->first] = offer.id;
         if (Player* player = GetPlayer(itr->first))
         {

--- a/src/game/Movement/MotionMaster.cpp
+++ b/src/game/Movement/MotionMaster.cpp
@@ -515,6 +515,29 @@ void MotionMaster::MovePoint(uint32 id, const Movement::Location& location, uint
     MovePoint(id, location.x, location.y, location.z, options, speed, finalOrientation);
 }
 
+void MotionMaster::MovePath(Movement::PointsArray const& pointPath, uint32 /*moveMode*/, bool flying, bool walk)
+{
+    // Need at least a start and an end vertex to build a spline.
+    if (pointPath.size() < 2)
+        return;
+
+    DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s movement by path (%u points)",
+                     m_owner->GetGuidStr().c_str(), uint32(pointPath.size()));
+
+    // Interrupt any active spline before launching the new one so the path
+    // starts cleanly from the unit's current position (Launch() rewrites the
+    // first vertex to the live position).
+    if (!m_owner->IsStopped())
+        m_owner->StopMoving();
+
+    Movement::MoveSplineInit init(*m_owner, "MotionMaster::MovePath");
+    init.MovebyPath(pointPath);
+    init.SetWalk(walk);             // walk == false => run speed
+    if (flying)
+        init.SetFly();
+    init.Launch();
+}
+
 void MotionMaster::MoveWaypointAsDefault(uint32 startPoint /*=0*/, uint32 source /*=0==PATH_NO_PATH*/, uint32 initialDelay /*=0*/, uint32 overwriteGuid /*=0*/, uint32 overwriteEntry /*=0*/, bool repeat /*=true*/)
 {
     if (m_owner->IsCreature())

--- a/src/game/Movement/MotionMaster.h
+++ b/src/game/Movement/MotionMaster.h
@@ -147,6 +147,10 @@ class MotionMaster : std::stack<MovementGenerator *>
         void MoveDistance(Unit* target, float distance);
         void ReInitializePatrolMovement();
 
+        // A module supplies a precomputed path and expects the unit to travel along
+        // it: a spline through the points, walk == false selects run speed.
+        void MovePath(Movement::PointsArray const& pointPath, uint32 moveMode, bool flying, bool walk = false);
+
         MovementGeneratorType GetCurrentMovementGeneratorType() const;
         static char const* GetMovementGeneratorTypeName(MovementGeneratorType generator);
         void GetUsedMovementGeneratorsList(std::vector<MovementGeneratorType>& list) const;

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -6426,6 +6426,22 @@ void Player::RepopAtGraveyard()
 
     // Special handle for battleground maps
     uint32 TeleOptions = TELE_TO_NOT_UNSUMMON_PET;
+
+    // A managed bot cannot click an instance portal: released to the outdoor
+    // graveyard it would stand there as a ghost for good while its group carried
+    // on. So it comes back alive just inside the instance entrance instead.
+    bool const repopAtEntrance = sScriptMgr.IsBotManaged(this);
+
+    if (!IsAlive() && repopAtEntrance && GetMap() && GetMap()->IsDungeon())
+    {
+        if (AreaTriggerTeleport const* entrance = sObjectMgr.GetMapEntranceTrigger(GetMapId()))
+        {
+            ResurrectPlayer(1.0f);
+            SpawnCorpseBones();
+            TeleportTo(entrance->destination, TeleOptions);
+            return;
+        }
+    }
     if (BattleGround *bg = GetBattleGround())
     {
         ClosestGrave = bg->GetClosestGraveYard(this);

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -3751,6 +3751,17 @@ bool Unit::AddSpellAuraHolder(SpellAuraHolder *holder)
     // When we call _AddSpellAuraHolder, we must have a free aura slot
     holder->_AddSpellAuraHolder();
 
+    // Module hook: a positive aura from another player, first application only --
+    // a refresh is not a new gift.
+    if (holder->IsPositive())
+        if (Unit* caster = holder->GetCaster())
+            if (caster != this && caster->IsPlayer())
+            {
+                const uint32 buffId = holder->GetId();
+                ScriptRegistry<UnitScript>::ForEachEnabledHook(UNITHOOK_ON_BUFF_RECEIVED,
+                    [&](UnitScript* s) { s->OnBuffReceived(this, (Player*)caster, buffId); });
+            }
+
     return true;
 }
 

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -1862,6 +1862,52 @@ AuraScript* ScriptMgr::GetAuraScript(SpellEntry const* pSpell)
     return pTempScript->GetAuraScript(pSpell);
 }
 
+bool ScriptMgr::IsBotManaged(Player* who)
+{
+    bool managed = false;
+    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_IS_MANAGED_BOT,
+        [&](PlayerScript* script) { if (script->IsManagedBot(who)) managed = true; });
+    return managed;
+}
+
+uint8 ScriptMgr::GetBotRoles(Player* who)
+{
+    uint8 roles = 0;
+    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_GET_BOT_ROLES,
+        [&](PlayerScript* script) { roles = uint8(roles | script->GetBotRoles(who)); });
+    return roles;
+}
+
+bool ScriptMgr::OnAddonMessage(Player* from, std::string const& msg)
+{
+    bool consumed = false;
+    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_ADDON_MESSAGE,
+        [&](PlayerScript* script) { if (!consumed && script->OnAddonMessage(from, msg)) consumed = true; });
+    return consumed;
+}
+
+bool ScriptMgr::OnWhoRequest(Player* from, std::string const& text)
+{
+    bool consumed = false;
+    ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_WHO_REQUEST,
+        [&](PlayerScript* script) { if (!consumed && script->OnWhoRequest(from, text)) consumed = true; });
+    return consumed;
+}
+
+uint32 ScriptMgr::AppendWhoResults(WorldPacket& data, uint32 have, uint32 levelMin, uint32 levelMax,
+            uint32 racemask, uint32 classmask, uint32 zonesCount, uint32 const* zoneids,
+            uint32 team, bool allowTwoSide, std::wstring const& wantName)
+{
+    uint32 total = 0;
+    ScriptRegistry<WorldScript>::ForEachEnabledHook(WORLDHOOK_APPEND_WHO,
+        [&](WorldScript* script)
+        {
+            total += script->OnAppendWho(data, have + total, levelMin, levelMax, racemask,
+                classmask, zonesCount, zoneids, team, allowTwoSide, wantName);
+        });
+    return total;
+}
+
 bool ScriptMgr::OnGossipHello(Player* pPlayer, Creature* pCreature)
 {
     Script* pTempScript = m_NPC_scripts[pCreature->GetScriptId()];

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -22,6 +22,7 @@
 #define _SCRIPTMGR_H
 
 #include "Common.h"
+#include <string>
 #include "Log.h"
 #include "Policies/Singleton.h"
 #include "ObjectGuid.h"
@@ -1517,6 +1518,8 @@ struct Script
     void RegisterSelf(bool reportUnused = true);
 };
 
+class WorldPacket;
+
 class ScriptMgr
 {
     public:
@@ -1608,6 +1611,13 @@ class ScriptMgr
 
         bool OnGossipHello(Player* pPlayer, Creature* pCreature);
         bool OnGossipHello(Player* pPlayer, GameObject* pGameObject);
+        bool IsBotManaged(Player* who);
+        uint8 GetBotRoles(Player* who);
+        bool OnAddonMessage(Player* from, std::string const& msg);
+        bool OnWhoRequest(Player* from, std::string const& text);
+        uint32 AppendWhoResults(WorldPacket& data, uint32 have, uint32 levelMin, uint32 levelMax,
+            uint32 racemask, uint32 classmask, uint32 zonesCount, uint32 const* zoneids,
+            uint32 team, bool allowTwoSide, std::wstring const& wantName);
         bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 sender, uint32 action, const char* code);
         bool OnGossipSelect(Player* pPlayer, GameObject* pGameObject, uint32 sender, uint32 action, const char* code);
         bool OnQuestAccept(Player* pPlayer, Creature* pCreature, Quest const* pQuest);

--- a/src/game/ScriptObjects.h
+++ b/src/game/ScriptObjects.h
@@ -78,6 +78,9 @@ enum WorldHook
     WORLDHOOK_ON_SHUTDOWN,
     WORLDHOOK_ON_AFTER_UNLOAD_ALL_MAPS,
     WORLDHOOK_ON_BEFORE_WORLD_INITIALIZED,
+    WORLDHOOK_ON_CHANNEL_BROADCAST,
+    WORLDHOOK_ON_BOT_LOGIN_YIELD,
+    WORLDHOOK_APPEND_WHO,
     WORLDHOOK_END
 };
 
@@ -104,6 +107,11 @@ class WorldScript : public ScriptObject
         virtual void OnShutdown() {}
         virtual void OnAfterUnloadAllMaps() {}
         virtual void OnBeforeWorldInitialized() {}
+        virtual void OnChannelBroadcast(uint32 /*guidLow*/, char const* /*channel*/, char const* /*msg*/) {}
+        virtual void OnBotLoginYield(uint32 /*guidLow*/) {}
+        virtual uint32 OnAppendWho(WorldPacket& /*data*/, uint32 /*have*/, uint32 /*levelMin*/, uint32 /*levelMax*/,
+            uint32 /*racemask*/, uint32 /*classmask*/, uint32 /*zonesCount*/, uint32 const* /*zoneids*/,
+            uint32 /*team*/, bool /*allowTwoSide*/, std::wstring const& /*wantName*/) { return 0; }
 };
 
 enum PlayerHook
@@ -140,6 +148,15 @@ enum PlayerHook
     PLAYERHOOK_ON_MAP_CHANGED,
     PLAYERHOOK_ON_BEFORE_TELEPORT,
     PLAYERHOOK_ON_LOOT_ITEM,
+    PLAYERHOOK_ON_CHAT_SAY,
+    PLAYERHOOK_ON_CHAT_CHANNEL,
+    PLAYERHOOK_ON_CHAT_WHISPER,
+    PLAYERHOOK_ON_CHAT_GUILD,
+    PLAYERHOOK_ON_TEXT_EMOTE_HEARD,
+    PLAYERHOOK_IS_MANAGED_BOT,
+    PLAYERHOOK_GET_BOT_ROLES,
+    PLAYERHOOK_ON_ADDON_MESSAGE,
+    PLAYERHOOK_ON_WHO_REQUEST,
     PLAYERHOOK_END
 };
 
@@ -186,6 +203,19 @@ class PlayerScript : public ScriptObject
         virtual void OnMapChanged(Player* /*player*/) {}
         virtual void OnBeforeTeleport(Player* /*player*/, uint32 /*mapId*/, float /*x*/, float /*y*/, float /*z*/, float /*orientation*/) {}
         virtual void OnLootItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, ObjectGuid /*lootGuid*/) {}
+        virtual void OnChatSay(Player* /*from*/, float /*range*/, char const* /*msg*/) {}
+        virtual void OnChatChannel(Player* /*from*/, char const* /*channel*/, char const* /*msg*/) {}
+        virtual void OnChatWhisper(Player* /*from*/, char const* /*msg*/) {}
+        virtual void OnChatGuild(Player* /*from*/, char const* /*msg*/) {}
+        virtual void OnTextEmoteHeard(Player* /*from*/, uint32 /*textEmote*/, ObjectGuid /*target*/) {}
+        virtual bool IsManagedBot(Player* /*who*/) { return false; }
+        virtual uint8 GetBotRoles(Player* /*who*/) { return 0; }
+
+        // A module may take an addon message, or the free text of a who-search, as a
+        // command of its own -- an addon that cannot speak can still search. Return
+        // true when the text was consumed; the core then neither relays nor searches.
+        virtual bool OnAddonMessage(Player* /*from*/, std::string const& /*msg*/) { return false; }
+        virtual bool OnWhoRequest(Player* /*from*/, std::string const& /*text*/) { return false; }
 };
 
 class CreatureScript : public ScriptObject, public UpdatableScript<Creature>
@@ -465,6 +495,7 @@ enum UnitHook
     UNITHOOK_ON_UNIT_ENTER_COMBAT,
     UNITHOOK_ON_UNIT_EXIT_COMBAT,
     UNITHOOK_ON_UNIT_DEATH,
+    UNITHOOK_ON_BUFF_RECEIVED,
     UNITHOOK_END
 };
 
@@ -490,6 +521,7 @@ class UnitScript : public ScriptObject
         virtual void OnUnitEnterCombat(Unit* /*unit*/, Unit* /*victim*/) {}
         virtual void OnUnitExitCombat(Unit* /*unit*/) {}
         virtual void OnUnitDeath(Unit* /*unit*/, Unit* /*killer*/) {}
+        virtual void OnBuffReceived(Unit* /*target*/, Player* /*caster*/, uint32 /*spellId*/) {}
 };
 
 class WorldObjectScript : public ScriptObject
@@ -700,6 +732,7 @@ class GroupScript : public ScriptObject
         virtual void OnRemoveMember(Group* /*group*/, ObjectGuid /*guid*/, uint8 /*method*/) {}
         virtual void OnChangeLeader(Group* /*group*/, ObjectGuid /*newLeaderGuid*/, ObjectGuid /*oldLeaderGuid*/) {}
         virtual void OnDisband(Group* /*group*/) {}
+        virtual void OnLootRollStarted(Group* /*group*/, ObjectGuid const& /*target*/, uint32 /*itemSlot*/, uint32 /*itemId*/) {}
 };
 
 class GuildScript : public ScriptObject
@@ -711,6 +744,7 @@ class GuildScript : public ScriptObject
         virtual void OnRemoveMember(Guild* /*guild*/, Player* /*player*/, bool /*isDisbanding*/, bool /*isKicked*/) {}
         virtual void OnCreate(Guild* /*guild*/, Player* /*leader*/, std::string const& /*name*/) {}
         virtual void OnDisband(Guild* /*guild*/) {}
+        virtual void OnGuildInvite(Player* /*invited*/) {}
 };
 
 class MailScript : public ScriptObject

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2533,10 +2533,6 @@ void TotalMoneyCallback(QueryResult* result, uint32 money)
 void World::Update(uint32 diff)
 {
     XScopeStatTimer ScopeStatTimer(sPerfMonitor.WorldTick);
-    ScriptRegistry<WorldScript>::ForEachEnabledHook(WORLDHOOK_ON_UPDATE, [&](WorldScript* script)
-    {
-        script->OnUpdate(diff);
-    });
 
     ///- Update the different timers
     for (auto& timer : m_timers)
@@ -2779,6 +2775,15 @@ void World::Update(uint32 diff)
             sWorld.ShutdownServ(900, SHUTDOWN_MASK_RESTART, SHUTDOWN_EXIT_CODE);
         }
     }
+
+    // Moved here from the head of this function. Firing first meant a module acted
+    // before UpdateSessions, sMapMgr, sBattleGroundMgr and sLFTMgr had run, so every
+    // module tick decided on the PREVIOUS tick's world -- a module may hold several
+    // WorldScripts and was steering sixty crews on stale positions.
+    ScriptRegistry<WorldScript>::ForEachEnabledHook(WORLDHOOK_ON_UPDATE, [&](WorldScript* script)
+    {
+        script->OnUpdate(diff);
+    });
 }
 
 /// Send a packet to all players (except self if mentioned)

--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -97,6 +97,8 @@ WorldSession::WorldSession(uint32 id, WorldSocket *sock, AccountTypes sec, time_
     MANGOS_ASSERT(!sock || transport == SessionTransport::Network);
 
     if (sock)
+    {
+        m_Address = remote_ip;
         sock->AddReference();
     }
     else


### PR DESCRIPTION
This adds the script hooks a module needs to run characters that have no client (headless sessions from bot-helpers), plus the few core behaviours such a character cannot do for itself. Everything is a no-op when no module implements it. It is what our inhabitant module (mod-kith, ~30k lines, lives outside this repo) needs from the core, and nothing else; the module has been running on this exact API on a live server.

Commits, each reviewable on its own:

1. **WorldSession: restore the block lost in merge #396** - the current bot-helpers head does not compile: the merge of cleanup/remove-playerbots left the constructor with an unmatched brace and dropped the address assignment in the socket branch. One-line restore of the pre-merge block. Feel free to take this one separately (branch fix/worldsession-merge-brace).

2. **Script hooks for bot modules**
   - PlayerScript: OnChatSay, OnChatChannel, OnChatWhisper, OnChatGuild, OnTextEmoteHeard (the emote packet carries its target, so "who was addressed" is not a guess), IsManagedBot, GetBotRoles, OnAddonMessage, OnWhoRequest.
   - WorldScript: OnChannelBroadcast (a channel line said by somebody with no client, taken on the caller's thread), OnBotLoginYield (a bot session holding a character yields to the real client logging in), OnAppendWho (a module appends its own rows to the who-list).
   - UnitScript::OnBuffReceived (first application of a positive aura by another player), GroupScript::OnLootRollStarted (a bot has no client to send CMSG_LOOT_ROLL; without this every roll it was part of ran its full thirty seconds and passed), GuildScript::OnGuildInvite.
   - ScriptMgr::IsBotManaged / GetBotRoles / OnAddonMessage / OnWhoRequest / AppendWhoResults as the dispatchers the core calls.
   - OnAddonMessage and OnWhoRequest let a module treat an addon message or the free text of a who-search as a command of its own (a client-side addon that cannot speak can still search). A module that consumes the text returns true; the core then neither relays nor searches. For that the who throttle moves below the name read; it is otherwise unchanged.
   - WORLDHOOK_ON_UPDATE fires at the end of World::Update instead of the head, after sessions, maps, battlegrounds and LFT have run, so a module acts on this tick rather than the previous one.

3. **Managed bots in LFT rolechecks and at the graveyard** - a managed bot answers a rolecheck at once with the roles its module reports, a party made only of managed bots completes the check immediately, a managed bot never queues on its own behalf. LFTManager::SignedUpRole keeps what somebody signed up as after the queue has let go of the entry (cleared on logout). A managed bot that died in a dungeon comes back alive just inside the instance entrance instead of standing at the outdoor graveyard as a ghost for good.

4. **ChatCommand: a module may bind a free function** - CommandScript::GetCommands returns entries whose Handler is a ChatHandler member pointer, so a module could only bind a command by declaring a member in the core. ChatCommand gains a trailing ModuleHandler (free function taking the handler and the args), defaulted to nullptr; existing tables are untouched.

5. **Read access for modules** - ChannelMgr::GetChannels, LFGQueue::GetPlayerQueueInfo, MotionMaster::MovePath (a spline through a precomputed path).

6. **modules: include the game subdirectories the game headers rely on** - the game headers include each other by bare name (ChannelMgr.h includes AbstractPlayer.h from MapNodes), so a module that includes one of them needs the same directories on its include path as the game target has.

Not included on purpose: our world-buff announcement hooks and the LFT bot-fill (both are fork features, kept in the module behind feature macros), and any compatibility aliases.

Built and run: bot-helpers + these commits + the module, full Release build, live on our server (one instance, ~500 headless characters).