### PR TITLE
MoveSpline: clamp a negative segment instead of asserting

### DIFF
--- a/src/game/Movement/spline/MoveSpline.cpp
+++ b/src/game/Movement/spline/MoveSpline.cpp
@@ -210,7 +210,21 @@ MoveSpline::UpdateResult MoveSpline::_updateState(int32& ms_time_diff)
     UpdateResult result = Result_None;
 
     int32 minimal_diff = std::min(ms_time_diff, segment_time_elapsed());
-    MANGOS_ASSERT(minimal_diff >= 0);
+    if (minimal_diff < 0)
+    {
+        // Elapsed time already past the next timestamp: a spline set up with a zero or
+        // negative segment. One creature like that took the whole server down on 6.9.
+        // (assertion, no core). Clamp, say so once a minute, and let the segment end.
+        static time_t s_saidAt = 0;
+        const time_t nowT = time(nullptr);
+        if (nowT - s_saidAt >= 60)
+        {
+            s_saidAt = nowT;
+            sLog.outError("MoveSpline::_updateState: minimal_diff %d < 0 (time_passed %d, next_timestamp %d, diff %d) -- clamped instead of asserting",
+                          minimal_diff, time_passed, next_timestamp(), ms_time_diff);
+        }
+        minimal_diff = 0;
+    }
     time_passed += minimal_diff;
     ms_time_diff -= minimal_diff;
 


### PR DESCRIPTION
A spline set up with a zero or negative segment made minimal_diff go below zero in MoveSpline::_updateState; the assertion took the whole server down (one creature, 6 September). Clamp to zero, log once a minute, and let the segment end. No behaviour change for valid splines.
