### PR TITLE
VMapManager2: guard the instance tree map with a shared mutex

### DIFF
--- a/src/game/vmap/VMapManager2.cpp
+++ b/src/game/vmap/VMapManager2.cpp
@@ -40,6 +40,7 @@ VMapManager2::VMapManager2()
 
 VMapManager2::~VMapManager2(void)
 {
+    std::unique_lock<std::shared_mutex> treeLock(m_treesLock);
     for (auto& iInstanceMapTree : iInstanceMapTrees)
         delete iInstanceMapTree.second;
 
@@ -90,6 +91,7 @@ VMAPLoadResult VMapManager2::loadMap(const char* pBasePath, unsigned int pMapId,
 
 bool VMapManager2::_loadMap(unsigned int pMapId, std::string const& basePath, uint32 tileX, uint32 tileY)
 {
+    std::unique_lock<std::shared_mutex> treeLock(m_treesLock);
     InstanceTreeMap::iterator instanceTree = iInstanceMapTrees.find(pMapId);
     if (instanceTree == iInstanceMapTrees.end())
     {
@@ -112,6 +114,7 @@ bool VMapManager2::_loadMap(unsigned int pMapId, std::string const& basePath, ui
 
 void VMapManager2::unloadMap(unsigned int pMapId)
 {
+    std::unique_lock<std::shared_mutex> treeLock(m_treesLock);
     InstanceTreeMap::iterator instanceTree = iInstanceMapTrees.find(pMapId);
     if (instanceTree != iInstanceMapTrees.end())
     {
@@ -128,6 +131,7 @@ void VMapManager2::unloadMap(unsigned int pMapId)
 
 void VMapManager2::unloadMap(unsigned int  pMapId, int x, int y)
 {
+    std::unique_lock<std::shared_mutex> treeLock(m_treesLock);
     InstanceTreeMap::iterator instanceTree = iInstanceMapTrees.find(pMapId);
     if (instanceTree != iInstanceMapTrees.end())
     {
@@ -144,6 +148,7 @@ void VMapManager2::unloadMap(unsigned int  pMapId, int x, int y)
 
 bool VMapManager2::isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2)
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     if (!isLineOfSightCalcEnabled()) return true;
     bool result = true;
     InstanceTreeMap::iterator instanceTree = iInstanceMapTrees.find(pMapId);
@@ -162,6 +167,7 @@ bool VMapManager2::isInLineOfSight(unsigned int pMapId, float x1, float y1, floa
 
 ModelInstance* VMapManager2::FindCollisionModel(unsigned int mapId, float x0, float y0, float z0, float x1, float y1, float z1)
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     if (!isLineOfSightCalcEnabled())
         return nullptr;
 
@@ -186,6 +192,7 @@ otherwise the result pos will be the dest pos
 */
 bool VMapManager2::getObjectHitPos(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float& ry, float& rz, float pModifyDist)
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     bool result = false;
     rx = x2;
     ry = y2;
@@ -217,6 +224,7 @@ get height or INVALID_HEIGHT if no height available
 
 float VMapManager2::getHeight(unsigned int pMapId, float x, float y, float z, float maxSearchDist)
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     float height = VMAP_INVALID_HEIGHT_VALUE;           // no height
     if (isHeightCalcEnabled())
     {
@@ -240,6 +248,7 @@ float VMapManager2::getHeight(unsigned int pMapId, float x, float y, float z, fl
 
 bool VMapManager2::getAreaInfo(unsigned int pMapId, float x, float y, float& z, uint32& flags, int32& adtId, int32& rootId, int32& groupId) const
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     bool result = false;
     InstanceTreeMap::const_iterator instanceTree = iInstanceMapTrees.find(pMapId);
     if (instanceTree != iInstanceMapTrees.end())
@@ -255,6 +264,7 @@ bool VMapManager2::getAreaInfo(unsigned int pMapId, float x, float y, float& z, 
 
 bool VMapManager2::isUnderModel(unsigned int pMapId, float x, float y, float z, float* outDist, float* inDist) const
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     bool result = false;
     InstanceTreeMap::const_iterator instanceTree = iInstanceMapTrees.find(pMapId);
     if (instanceTree != iInstanceMapTrees.end())
@@ -268,6 +278,7 @@ bool VMapManager2::isUnderModel(unsigned int pMapId, float x, float y, float z, 
 
 bool VMapManager2::GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 ReqLiquidType, float& level, float& floor, uint32& type) const
 {
+    std::shared_lock<std::shared_mutex> treeLock(m_treesLock);
     InstanceTreeMap::const_iterator instanceTree = iInstanceMapTrees.find(pMapId);
     if (instanceTree != iInstanceMapTrees.end())
     {

--- a/src/game/vmap/VMapManager2.h
+++ b/src/game/vmap/VMapManager2.h
@@ -71,6 +71,18 @@ namespace VMAP
             /* void _unloadMap(uint32 pMapId, uint32 x, uint32 y); */
 
             std::shared_mutex m_modelsLock;
+
+            // Guards iInstanceMapTrees and the tiles hanging off it. The models
+            // lock above only covers the model file cache; the tree map itself
+            // was unsynchronised, while the playerbot travel search calls the
+            // query methods below from std::async worker threads and the world
+            // thread loads and unloads tiles underneath them. That raced, and
+            // it crashed in all three places - LoadMapTile, ~StaticMapTree and
+            // getAreaInfo. Mutable because the const query methods need it.
+            // Order is always this lock first, m_modelsLock second: _loadMap
+            // reaches acquireModelInstance through LoadMapTile, and nothing
+            // holding m_modelsLock ever touches the trees.
+            mutable std::shared_mutex m_treesLock;
         public:
             // public for debug
             G3D::Vector3 convertPositionToInternalRep(float x, float y, float z) const;


### PR DESCRIPTION
Map tiles are loaded and unloaded on the world thread while line-of-sight, height and area queries run from other threads; the map of instance trees was read and modified concurrently. Writers (load, unload, destructor) take a unique lock, readers (isInLineOfSight, getObjectHitPos, getHeight, getAreaInfo, FindCollisionModel) a shared one. No behaviour change otherwise.