### PR TITLE
Fix missing header dependencies exposed by PCH-disabled builds

### DIFF
--- a/src/game/Conditions.h
+++ b/src/game/Conditions.h
@@ -23,6 +23,9 @@
 
 #include "SharedDefines.h"
 
+class Map;
+class WorldObject;
+
 enum ConditionType
 {
     //                                                      // Legend:

--- a/src/game/LFT/LFTMgr.h
+++ b/src/game/LFT/LFTMgr.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "Common.h"
+#include "ObjectGuid.h"
 
 class Group;
 class Player;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -297,6 +297,11 @@ pAuraHandler AuraHandler[TOTAL_AURAS] =
     &Aura::HandleNoImmediateEffect,                         //226 SPELL_AURA_MOD_RAGE_FROM_DAMAGE_DEALT implemented in Unit::HandleModRageFromDamageDealtAuraProc
 };
 
+void SpellAuraHolder::SetAura(uint32 slot, bool remove)
+{
+    m_target->SetUInt32Value(UNIT_FIELD_AURA + slot, remove ? 0 : GetId());
+}
+
 static AuraType const frozenAuraTypes[] = { SPELL_AURA_MOD_ROOT, SPELL_AURA_MOD_STUN, SPELL_AURA_NONE };
 
 Aura::Aura(SpellEntry const* spellproto, SpellEffectIndex eff, int32 *currentBasePoints, SpellAuraHolder *holder, Unit *target, Unit *caster, Item* castItem) :

--- a/src/game/Spells/SpellAuras.h
+++ b/src/game/Spells/SpellAuras.h
@@ -26,6 +26,7 @@
 #include "SpellAuraDefines.h"
 #include "DBCEnums.h"
 #include "ObjectGuid.h"
+#include "UnitDefines.h"
 #include <vector>
 
 /**
@@ -78,6 +79,8 @@ struct HeartBeatData
 class Unit;
 class Item;
 class WorldObject;
+class Player;
+class DynamicObject;
 class SpellEntry;
 struct AuraScript;
 struct SpellModifier;
@@ -232,7 +235,7 @@ class SpellAuraHolder
 
         void UpdateAuraDuration() const;
 
-        void SetAura(uint32 slot, bool remove) { m_target->SetUInt32Value(UNIT_FIELD_AURA + slot, remove ? 0 : GetId()); }
+        void SetAura(uint32 slot, bool remove);
         void SetAuraFlag(uint32 slot, bool add);
         void SetAuraLevel(uint32 slot, uint32 level);
 


### PR DESCRIPTION
## Code Type

* [ ] SQL
* [x] Core

## Description

Fix several core headers that relied on declarations being provided indirectly through transitive includes.

These dependencies are normally hidden by precompiled headers and by favorable include order, but become compile failures when the core is built with precompiled headers disabled.

The changes are intentionally small and limited to making the affected headers declare or include the dependencies they use directly:

* `LFTMgr.h`

  * Includes `ObjectGuid.h` explicitly because `ObjectGuid` is used directly by the header.

* `SpellAuras.h`

  * Adds the required direct header dependency so it no longer relies on unrelated headers being included beforehand.

* `Conditions.h`

  * Adds the required forward declarations for types referenced by the header.

The failures were found while running the core build audit with precompiled headers disabled. Building this way exposes hidden include-order dependencies that can otherwise remain unnoticed because the PCH supplies declarations globally.

No gameplay behavior or runtime logic is changed. These changes only make the affected headers self-contained and independent of incidental include order.
