### PR TITLE
fix(core): allow headless sessions to process queued packets

### DIFF
--- a/src/game/WorldSession.cpp
+++ b/src/game/WorldSession.cpp
@@ -447,7 +447,9 @@ bool WorldSession::Update(PacketFilter& updater)
 
 bool WorldSession::CanProcessPackets() const
 {
-    return (m_Socket && !m_Socket->IsClosed());
+    // Headless sessions have no socket, but trusted native modules may enqueue
+    // synthetic client packets for the normal opcode handlers.
+    return IsHeadless() || (m_Socket && !m_Socket->IsClosed());
 }
 
 void WorldSession::ProcessPackets(PacketFilter& updater)


### PR DESCRIPTION
Split of #474 per review — headless half only, ready to merge.

## What this fixes

Bots use headless sessions: normal player sessions without a real client connection. Some bot actions go through the same internal packet queue used by the game client, but the core only drained that queue when a real network connection existed, so packets enqueued by a headless bot (movement, item use, teleport, group interactions) could sit unprocessed.

Allows a headless session to process its own trusted internal queue. No new remote-client packet path; does not claim a network connection.

## Scope

One file: `src/game/WorldSession.cpp` (`CanProcessPackets()` returns true for `IsHeadless()`). No bot-specific object or manager in the core; network-session behavior unchanged.

## Validation

- `git diff --check`
- TortoiseBots Penqle host-contract check
- Tortoise WoW 1.18.1 module-surface check
- Full Docker Release build with TortoiseBots enabled as a static module; `mangosd` built successfully (per #474; this is the unchanged headless hunk of that build)

No live-client gameplay test yet.

Supersedes the headless half of #474. Chat-hook hardening follows separately in the sibling PR.