### PR TITLE
Windows install: deploy the OpenSSL 3 DLLs mangosd.exe also needs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,43 @@ if(WIN32)
     DESTINATION ${LIBS_DIR}
     CONFIGURATIONS Debug
   )
+
+  # The pair above is not the only OpenSSL this binary ends up needing. OPENSSL_INCLUDE_DIR,
+  # set below to dep/windows/include/openssl, is the "openssl" folder itself rather than its
+  # parent - so "#include <openssl/x.h>", the form every file that actually touches OpenSSL
+  # here uses (src/shared/Auth/ARC4.cpp, BigNumber.cpp, the HTTP API's httplib.h), can never
+  # resolve through it. Those includes are satisfied by whatever else on the include path is
+  # laid out as include/openssl/*.h instead - on a build configured the way this project's own
+  # testlab pipeline configures one (ACE_ROOT pointed at a vcpkg installed tree), that is
+  # vcpkg's OpenSSL, which is 3.x. ARC4.cpp calls OSSL_PROVIDER_load(NULL, "legacy") to keep
+  # RC4 available for the login handshake - an OpenSSL-3-only API, no 1.1 equivalent - so this
+  # is a real dependency and not incidental: confirmed with dumpbin /dependents, mangosd.exe
+  # imports from both libcrypto-1_1-x64.dll AND libcrypto-3-x64.dll at once, not either/or.
+  #
+  # Deployed the same way ACE.dll and the Boost DLLs already are for this build - read from
+  # ACE_ROOT, since that is this project's own established way of pointing a Windows build at
+  # its vcpkg toolchain - but with file(GLOB), not a hard requirement: ACE_ROOT is not
+  # guaranteed to be a vcpkg tree with OpenSSL 3 sitting in it for every possible Windows build
+  # of this project, only for the one the pipeline produces, and a build that does not find
+  # these should not fail here over a DLL a different OpenSSL setup may not need at all.
+  if(ACE_ROOT)
+    # ACE_ROOT commonly arrives with Windows backslashes (-DACE_ROOT=C:\path	ocpkg, which
+    # is exactly how this project's own pipeline passes it). file(GLOB) matches fine against
+    # that, but embeds whatever it matched verbatim into the generated cmake_install.cmake -
+    # and an unescaped backslash there is a syntax error the moment it precedes a letter CMake
+    # does not recognise as an escape (, \l, ...). Normalizing first is what the rest of
+    # this file already relies on CMake doing for CMAKE_SOURCE_DIR-based paths automatically.
+    file(TO_CMAKE_PATH "${ACE_ROOT}" ACE_ROOT_NORMALIZED)
+    file(GLOB OPENSSL3_RELEASE_DLLS "${ACE_ROOT_NORMALIZED}/bin/libcrypto-3${OPENSSL_DLL_SUFFIX}.dll" "${ACE_ROOT_NORMALIZED}/bin/libssl-3${OPENSSL_DLL_SUFFIX}.dll")
+    file(GLOB OPENSSL3_DEBUG_DLLS   "${ACE_ROOT_NORMALIZED}/debug/bin/libcrypto-3${OPENSSL_DLL_SUFFIX}.dll" "${ACE_ROOT_NORMALIZED}/debug/bin/libssl-3${OPENSSL_DLL_SUFFIX}.dll")
+    if(OPENSSL3_RELEASE_DLLS)
+      install(FILES ${OPENSSL3_RELEASE_DLLS} DESTINATION ${LIBS_DIR} CONFIGURATIONS Release)
+    endif()
+    if(OPENSSL3_DEBUG_DLLS)
+      install(FILES ${OPENSSL3_DEBUG_DLLS} DESTINATION ${LIBS_DIR} CONFIGURATIONS Debug)
+    endif()
+  endif()
+
   if(PLATFORM MATCHES X86)
     # Copy dll's Windows needs
     install(


### PR DESCRIPTION
## Issue this resolves
<!-- Please link to an issue. Create one first if needed. -->
- Closes #485

## Code Type
- [ ]  SQL
- [ ]  Core
- [x]  Tooling / install (`install()` step in `CMakeLists.txt`, no gameplay code)

## Description
<!-- What was changed? Why was it necessary? Any relevant context? -->

`mangosd.exe` failed to start: `STATUS_DLL_NOT_FOUND` on `libcrypto-3-x64.dll`.

Traced with `dumpbin /dependents` rather than guessed at. `mangosd.exe` imports from two separate OpenSSL DLL families at once — `libcrypto-1_1-x64.dll` (`dep/windows`, already deployed by `install()`) and `libcrypto-3-x64.dll` (not deployed anywhere) — and they are not redundant with each other.

`OPENSSL_INCLUDE_DIR` on Windows is set to the `openssl` folder itself rather than its parent, so it cannot satisfy the `#include <openssl/x.h>` form every core file that touches OpenSSL actually uses (`src/shared/Auth/ARC4.cpp`, `BigNumber.cpp`, the HTTP API's `httplib.h`). Those resolve through whatever else on the include path is laid out as `include/openssl/*.h` instead — on a build configured the way this project's own testlab pipeline configures one (`ACE_ROOT` pointed at a vcpkg installed tree), that's vcpkg's OpenSSL, which is 3.x. `ARC4.cpp` calls `OSSL_PROVIDER_load(NULL, "legacy")` to keep RC4 available for the login handshake — an OpenSSL-3-only API with no 1.1 equivalent — so this is a real dependency, not an accident.

`realmd.exe` does not touch this path (checked the same way) and needs only the 1.1 pair, so it's untouched here.

### What changed

Deployed `libcrypto-3-x64.dll`/`libssl-3-x64.dll` from `ACE_ROOT/bin`, the same place `ACE.dll` and the Boost DLLs are already read from for this build — but through `file(GLOB)` rather than a hard requirement, since `ACE_ROOT` isn't guaranteed to be a vcpkg tree with OpenSSL 3 in it for every possible Windows build of this project, only for the one the documented pipeline produces. A build that doesn't find these shouldn't fail over a DLL a different OpenSSL setup may not need at all.

One thing that only showed up by actually running the install step, not just reading the diff: `ACE_ROOT` commonly carries Windows backslashes (`-DACE_ROOT=C:\path\to\vcpkg` is literally how the pipeline passes it). `file(GLOB)` matches fine against that, but embeds what it matched into the generated `cmake_install.cmake` verbatim, and an unescaped backslash there is a syntax error the moment it precedes a letter CMake doesn't read as an escape. `file(TO_CMAKE_PATH ...)` first fixes it — included in this PR, not a followup.

### Out of scope, flagged rather than fixed here

`OPENSSL_INCLUDE_DIR`/`OPENSSL_LIBRARIES` themselves stay pointed at `dep/windows` on Windows, even though — as far as I can tell — nothing can actually resolve `#include <openssl/x.h>` through them (see above). Fixing that properly looks like it would mean either correcting the include path (which raises the question of whether `dep/windows`'s bundled 1.1 blob is still needed for anything, since it lacks `provider.h` entirely and can't be what `ARC4.cpp` needs) or declaring the real, vcpkg-sourced OpenSSL 3 dependency explicitly via `find_package(OpenSSL REQUIRED)` on Windows the way `UNIX` already does. Either is a bigger, riskier change than deploying the DLL the binary is already reaching for, so I left it as a comment in the code pointing at this PR rather than taking it on unprompted.

## Testing

- **Build/checks:** Did not do a full rebuild from scratch for this — reconfigured an existing `bot-helpers` build tree (`ACE_ROOT` pointed at the same vcpkg tree the pipeline uses) against the patched `CMakeLists.txt`, then ran `cmake --install --config Release` directly against it. `libcrypto-3-x64.dll` and `libssl-3-x64.dll` installed cleanly; everything else in that server directory — `mangosd.exe`, `realmd.exe`, `aiplayerbot.conf`, the module confs — came back "Up-to-date", confirming the change is additive and doesn't touch anything else the install step manages.
- **Runtime testing:** `mangosd.exe` starts past the point it previously failed at, with the two DLLs in place.

## Notes

Caveat on the fix itself: it assumes `ACE_ROOT` points at a vcpkg-style installed tree with OpenSSL 3 alongside it, which is true for this project's own documented pipeline build but not guaranteed for every possible Windows build configuration. `file(GLOB)` rather than a required install keeps a build that doesn't have that from failing over it.
