### PR TITLE
Generate revision header in the build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,9 +327,18 @@ else()
     set(rev_date "1970-01-01 00:00:00 +0000")
     set(rev_hash "unknown")
   endif()
-  
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/revision.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/src/shared/revision.h)
 endif()
+
+# Keep generated revision metadata out of the tracked source tree.
+# The generated include directory is placed first so <revision.h>
+# resolves to this build-specific header rather than src/shared/revision.h.
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/generated")
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/revision.h.cmake"
+  "${CMAKE_BINARY_DIR}/generated/revision.h"
+  @ONLY
+)
+include_directories(BEFORE "${CMAKE_BINARY_DIR}/generated")
 
 message(STATUS "")
 message(STATUS "Core revision: ${rev_hash} ${rev_date} ")

--- a/src/shared/SystemConfig.h
+++ b/src/shared/SystemConfig.h
@@ -23,7 +23,7 @@
 #define MANGOS_SYSTEMCONFIG_H
 
 #include "Platform/Define.h"
-#include "revision.h"
+#include <revision.h>
 
 // Format is YYYYMMDDRR where RR is the change in the conf file
 // for that day.


### PR DESCRIPTION
### Generate revision header in the build tree

## Code Type
- [ ]  SQL
- [x]  Core

## Description

Generate `revision.h` in the build tree instead of writing generated revision metadata into the source checkout.

The current CMake configuration writes the generated header to `src/shared/revision.h`. This mixes build-specific state with the source tree and means that configuring an otherwise out-of-source build still modifies files inside the checkout.

This PR moves the generated header to `${CMAKE_BINARY_DIR}/generated/revision.h` and places the generated include directory before the source include directories.

## Why

`revision.h` is generated build metadata and should belong to the build tree rather than the source tree.

Keeping it in the source checkout has several undesirable properties:

* configuring the project modifies the source tree;
* separate build directories share the same generated revision header;
* one build configuration can overwrite revision metadata used by another;
* source archives or other builds without a usable Git executable do not reliably generate the header.

The project already provides fallback revision values when Git is unavailable, but the existing `configure_file()` call is inside the Git-enabled branch. As a result, those fallback values can be set without actually generating `revision.h`.

This change moves header generation outside that conditional so both normal Git builds and Git-less/source-archive builds follow the same deterministic path.

## Include resolution

`SystemConfig.h` is changed from a quoted `revision.h` include to the include-path form `<revision.h>`.

This is intentional.

A quoted include searches the directory containing `SystemConfig.h` first, which could prefer a source-tree `src/shared/revision.h` over the build-specific generated header.

Using the include-path form together with the generated directory being added first ensures that the header belonging to the current build tree is selected.

## Result

After this change:

* generated revision metadata stays out of the source checkout;
* each build directory gets its own `revision.h`;
* multiple out-of-tree builds no longer share generated revision state;
* Git-less/source-archive configurations still generate a valid revision header using the existing fallback values;
* no runtime, database, or client behavior is changed.

## Testing

* Applied cleanly against the current `1181dev` branch.
* Linux build: successful.
* Windows build: successful.

No database or client-side changes are required.
