### PR TITLE
core: add Player::BeginTradeWith for server-side trade initiation

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -599,6 +599,44 @@ void TradeData::SetAccepted(bool state, bool crosssend /*= false*/)
 
 //== Player ====================================================
 
+// Server-side / scriptable trade initiation. Mirrors the setup of
+// WorldSession::HandleInitiateTradeOpcode (same guards), but performs no item,
+// gold or accept action -- the actual exchange stays fully gated by the normal
+// HandleAcceptTradeOpcode path. Purely additive; no existing code path changes.
+bool Player::BeginTradeWith(Player* other)
+{
+    if (!other || other == this)
+        return false;
+    if (m_trade || other->m_trade)
+        return false;
+    if (!IsAlive() || !other->IsAlive())
+        return false;
+    if (HasUnitState(UNIT_STAT_STUNNED | UNIT_STAT_PENDING_STUNNED) ||
+        other->HasUnitState(UNIT_STAT_STUNNED | UNIT_STAT_PENDING_STUNNED))
+        return false;
+    if ((GetSession() && GetSession()->isLogingOut()) ||
+        (other->GetSession() && other->GetSession()->isLogingOut()))
+        return false;
+    if (IsTaxiFlying() || other->IsTaxiFlying() || !FindMap() || GetMap() != other->GetMap())
+        return false;
+    if (GetDistance3dToCenter(other) > TRADE_DISTANCE)
+        return false;
+    if (!sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_TRADE) && GetTeam() != other->GetTeam())
+        return false;
+
+    m_trade = new TradeData(this, other);
+    other->m_trade = new TradeData(other, this);
+    m_trade->SetScamPreventionDelay(200);
+    other->m_trade->SetScamPreventionDelay(200);
+
+    WorldPacket data(SMSG_TRADE_STATUS, 12);
+    data << uint32(TRADE_STATUS_BEGIN_TRADE);
+    data << ObjectGuid(GetObjectGuid());
+    if (other->GetSession())
+        other->GetSession()->SendPacket(&data);
+    return true;
+}
+
 UpdateMask Player::updateVisualBits;
 
 Player::Player(WorldSession *session) : Unit(),

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1404,6 +1404,11 @@ class Player final: public Unit
 
         Player* GetTrader() const { return m_trade ? m_trade->GetTrader() : nullptr; }
         TradeData* GetTradeData() const { return m_trade; }
+        // Server-side / scriptable trade initiation: opens the trade window with
+        // `other` using the same preconditions as the CMSG_INITIATE_TRADE handler,
+        // then leaves items, gold and acceptance to the normal trade path. Purely
+        // additive -- changes no existing behaviour. False if a precondition fails.
+        bool BeginTradeWith(Player* other);
         void TradeCancel(bool sendback, TradeStatus status = TRADE_STATUS_TRADE_CANCELED);
 
         uint32 GetTimeLoggedIn() const { return m_timeLoggedIn; }


### PR DESCRIPTION
<details><summary>PR 1 Body</summary>

What changed: Adds Player::BeginTradeWith(other) so server-side code can open a trade window with a player like the client's CMSG_INITIATE_TRADE does — same guards, sends SMSG_TRADE_STATUS BEGIN_TRADE. Purely additive.
Relates to: lets a module (clientless resident bots) hand items over through a real trade window instead of silently injecting them.
Testing: built on VM 103; residents open a trade window and hand over goods; guards mirror HandleInitiateTradeOpcode.
Notes: no existing behaviour changes; unused unless a module calls it.