### PR TITLE
core: add PlayerScript OnChatYell hook

### DIFF
--- a/src/game/Handlers/ChatHandler.cpp
+++ b/src/game/Handlers/ChatHandler.cpp
@@ -589,6 +589,11 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket & recv_data)
             GetPlayer()->Yell(msg, lang);
 
             if (lang != LANG_ADDON)
+                ScriptRegistry<PlayerScript>::ForEachEnabledHook(PLAYERHOOK_ON_CHAT_YELL,
+                    [&](PlayerScript* s) { s->OnChatYell(GetPlayer(),
+                        sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL), msg.c_str()); });
+
+            if (lang != LANG_ADDON)
             {
                 sWorld.LogChat(this, "Yell", msg);
             }

--- a/src/game/ScriptObjects.h
+++ b/src/game/ScriptObjects.h
@@ -145,6 +145,7 @@ enum PlayerHook
     PLAYERHOOK_ON_BEFORE_TELEPORT,
     PLAYERHOOK_ON_LOOT_ITEM,
     PLAYERHOOK_ON_CHAT_SAY,
+    PLAYERHOOK_ON_CHAT_YELL,
     PLAYERHOOK_ON_CHAT_CHANNEL,
     PLAYERHOOK_ON_CHAT_WHISPER,
     PLAYERHOOK_ON_CHAT_GUILD,
@@ -199,6 +200,7 @@ class PlayerScript : public ScriptObject
         virtual void OnBeforeTeleport(Player* /*player*/, uint32 /*mapId*/, float /*x*/, float /*y*/, float /*z*/, float /*orientation*/) {}
         virtual void OnLootItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, ObjectGuid /*lootGuid*/) {}
         virtual void OnChatSay(Player* /*from*/, float /*range*/, char const* /*msg*/) {}
+        virtual void OnChatYell(Player* /*from*/, float /*range*/, char const* /*msg*/) {}
         virtual void OnChatChannel(Player* /*from*/, char const* /*channel*/, char const* /*msg*/) {}
         virtual void OnChatWhisper(Player* /*from*/, char const* /*msg*/) {}
         virtual void OnChatGuild(Player* /*from*/, char const* /*msg*/) {}


### PR DESCRIPTION
</details>

<details><summary>PR 2 Body</summary>

What changed: Adds PLAYERHOOK_ON_CHAT_YELL + OnChatYell(Player*, range, msg), fired from the CHAT_MSG_YELL path exactly like the existing OnChatSay hook (lang != LANG_ADDON, yell listen range).
Relates to: parity with OnChatSay/OnChatChannel so a module can react to /yell. Depends on the chat hooks in this branch.
Testing: built on VM 103; a module takes yell'd offers (resident bots).
Notes: additive; base is bot-helpers due to the chat-hook dependency — retarget to main once that lands.
